### PR TITLE
Add Fall 2019 courses to hardcoded update list

### DIFF
--- a/editor/editor.d
+++ b/editor/editor.d
@@ -2491,7 +2491,7 @@ class EditorApi : ApiProvider {
 		auto canvas = getCanvasApiClient(productionCredentials());
 
 		// live things
-		auto req = canvas.httpClient.navigateTo(arsd.http2.Uri("https://portal.bebraven.org/bz/course_cohort_information?course_ids[]=56&course_ids[]=62&course_ids[]=57&course_ids[]=58&course_ids[]=71&course_ids[]=73&course_ids[]=81&access_token=" ~ canvas.oauth2Token));
+		auto req = canvas.httpClient.navigateTo(arsd.http2.Uri("https://portal.bebraven.org/bz/course_cohort_information?course_ids[]=71&course_ids[]=73&course_ids[]=81&access_token=" ~ canvas.oauth2Token));
 
 		// lc playbooks
 		//auto req = canvas.httpClient.navigateTo(arsd.http2.Uri("https://portal.bebraven.org/bz/course_cohort_information?course_ids[]=59&course_ids[]=60&course_ids[]=61&access_token=" ~ canvas.oauth2Token));

--- a/editor/editor.d
+++ b/editor/editor.d
@@ -2491,7 +2491,7 @@ class EditorApi : ApiProvider {
 		auto canvas = getCanvasApiClient(productionCredentials());
 
 		// live things
-		auto req = canvas.httpClient.navigateTo(arsd.http2.Uri("https://portal.bebraven.org/bz/course_cohort_information?course_ids[]=56&course_ids[]=62&course_ids[]=57&course_ids[]=58&access_token=" ~ canvas.oauth2Token));
+		auto req = canvas.httpClient.navigateTo(arsd.http2.Uri("https://portal.bebraven.org/bz/course_cohort_information?course_ids[]=56&course_ids[]=62&course_ids[]=57&course_ids[]=58&course_ids[]=71&course_ids[]=73&course_ids[]=81&access_token=" ~ canvas.oauth2Token));
 
 		// lc playbooks
 		//auto req = canvas.httpClient.navigateTo(arsd.http2.Uri("https://portal.bebraven.org/bz/course_cohort_information?course_ids[]=59&course_ids[]=60&course_ids[]=61&access_token=" ~ canvas.oauth2Token));


### PR DESCRIPTION
Task: https://app.asana.com/0/1128645836596228/1139269835032409/f

Summary: We want to pull in Canvas data into the magic field answers sqlite db on the editor analytics util. This adds Fall19SJSU, Fall19RUN, and BravenXPilot to the hardcoded list of courses to pull in answers from.

Once this is in, someone will have to go to hit the URL in a browser to actually pull in the data.
