### PR TITLE
Conditionalized Mastery Questions Progress Sidebar Tracker

### DIFF
--- a/bz_custom.js
+++ b/bz_custom.js
@@ -171,6 +171,11 @@ jQuery( document ).ready(function() {
         return jQuery(this).text();
       }
     });
+      
+    /* Hide Mastery Questions Progress Sidebar when there aren't any questions on the page */
+    if ($(".bz-graded-question ol li").length === 0){
+      jQuery("#bz-progress-bar .bz-graded-question").hide();
+    }
 
     /* Application Ritual functionality: */
     // Update table when new value is added


### PR DESCRIPTION
We want to hide the Mastery Questions Progress Sidebar Tracker when there aren't any mastery questions on the page. 
Ticket:
https://app.asana.com/0/1128645836596228/1143371089444598