### PR TITLE
Adds custom_switch.js to switch between old and new JS

### DIFF
--- a/custom_switch.js
+++ b/custom_switch.js
@@ -1,0 +1,5 @@
+var scriptElement = document.createElement('script');
+var scriptSrc = document.currentScript.src;
+var customJS = window.BRAVEN_NEW_HTML ? 'braven_custom' : 'bz_custom'
+scriptElement.src = scriptSrc.replace('custom_switch', customJS);
+document.head.appendChild(scriptElement);


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1142638035116665/1155859225081693/f
https://app.asana.com/0/1135788329634534/1164537680281633

**Related PRs**:
https://github.com/beyond-z/canvas-lms/pull/569
https://github.com/bebraven/platform/pull/113

**Description**:
This script is used to switch between `braven_custom.js` for new HTML and `bz_custom.js` for old HTML. It looks for the presence of the window object `BRAVEN_NEW_HTML` (true when the meta tag `'<!-- BRAVEN_NEW_HTML -->'` is detected) and determines which one to load based on that. The inserted script element is immediately executed after it is inserted into the DOM.