### PR TITLE
Removes Empty Inline Feedback

### DIFF
--- a/braven_custom.js
+++ b/braven_custom.js
@@ -1400,6 +1400,14 @@ runOnUserContent(function(){
     if ($(".bz-graded-question ol li").length === 0){
       jQuery("#bz-progress-bar .bz-graded-question").hide();
     }
+
+    // Remove empty inline feedback
+    jQuery('.inline.feedback').each(function(_, e) { 
+      let $feedback = jQuery(e);
+      if(!$feedback.text().trim()) {
+        $feedback.remove();
+      }
+    })
   });
 
   var position_magic_field_name = window.position_magic_field_name ? window.position_magic_field_name : ("module_position_" + ENV["WIKI_PAGE"].page_id);


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1142638035116665/1164749808736665/f

**Description**:
This following code removes empty inline feedback after retained data is loaded. This isn't ideal, but because NCE adds empty characters when it generated, we can't do a simple CSS fix using `:empty()`.