### PR TITLE
Add braven_newui.css

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -3319,15 +3319,12 @@ blockquote {
     margin-top: 4px
 }
 
-.bz-module input[data-correctness="correct"] + label {
-    color: green;
+.show-answers input[data-correctness="correct"]:checked + label {
+    color: #22B573;
 }
-
-.bz-module input[data-correctness="incorrect"] + label {
-    color: red;
+.show-answers input[data-correctness="correct"]:not(:checked) + label {
+    color: #B08833;
 }
-
-.bz-module input[data-correctness="maybe"] + label,
-.bz-module input[data-correctness=""] + label {
-    color: #a54c2a;
+.show-answers input[data-correctness="incorrect"] + label {
+    color: #EB3B46;
 }

--- a/braven_newui.css
+++ b/braven_newui.css
@@ -1,0 +1,3333 @@
+/* Custom CSS for new UI that is more interactive.  Applied to new courses after we made the change (Fall 2017) */
+
+/* Custom header stuff: */
+/* -------------------- */
+#header {
+	background-color: #234;
+	background-image: url("braven_bkg_70h_canvas.png");
+}
+
+#header-logo {
+	background-image:url("braven_logo_canvas_red_white.png");
+}
+
+#menu>li,
+#identity {
+	background: rgba(0, 0, 0, 0.2);
+}
+
+#identity {
+	border-bottom-left-radius: 0;
+	border-bottom-right-radius: 0;
+}
+
+#identity .emphasize-name {
+	color:  #eddcbe;
+}
+
+/* TYPOGRAPHY */
+body {
+	font-family: Georgia, serif;
+}
+
+.bz-heading,
+th,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.menu-item,
+nav li,
+#identity li,
+.module-sequence-footer,
+.btn,
+.bz-ajax-loaded-rubric .nobr,
+.bz-ajax-loaded-rubric td.criterion_description,
+.bz-expand-collapse-button,
+input[type="button"],
+.media-duration,
+.media-instructions,
+th,
+.match-heading-style,
+.inner-toc,
+.main-toc,
+.toggle-transcript,
+.ic-notification__title,
+.bz-button-pick-up,
+.bz-explain-grade-link a,
+.bz-graded-question:before {
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+	text-transform: uppercase;
+	line-height: normal;
+	font-weight: normal;
+	font-size: 1.2em;
+}
+
+.bz-module,
+.assignment .description {
+	font-size: 18px;
+	line-height: 1.25;
+}
+
+.bz-module li {
+	line-height: normal;
+	margin-bottom: 0.5em;
+}
+
+a,
+.reveal-next {
+	color: #2E6D99;
+	cursor: pointer
+}
+
+a:visited {
+	color: #235877;
+}
+
+#menu a.menu-item-no-drop:focus,
+#menu a.menu-item-no-drop:hover,
+#menu > .menu-item > a:visited {
+	color: #fff;
+}
+
+.bz-module .bz-module h2,
+.bz-module .bz-module h3,
+.bz-module .bz-module h4 {
+	margin-top: 3em;
+}
+
+.bz-module h2,
+.bz-module h4,
+.bz-module h6 {
+	color: #EB3B46;
+}
+
+.bz-module h2,
+.bz-assignment h3 {
+	font-size: 40px;
+}
+
+.bz-assignment h3 {
+  padding-top: 0.5em;
+}
+
+.bz-module h3 {
+	font-size: 34px;
+}
+
+.bz-module h4 {
+	font-size: 27px;
+}
+
+.bz-module h6,
+.bz-module .inner-toc,
+.bz-module .main-toc {
+ font-size: 16px;
+ letter-spacing: 0.1em;
+}
+
+.bz-assignment h5 {
+  color: black;
+}
+
+.bz-module .main-toc {
+	margin: 20px 0 3em;
+}
+
+.bz-module h5,
+.bz-module .box-title {
+	font-size: 24px;
+}
+
+.bz-dynamic-syllabus h3 {
+	font-size: 18px;
+	margin: 10px auto;
+}
+
+.bz-course-part-module-box  > * {
+	width: 200px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.bz-module .main-toc ol,
+.bz-module .main-toc li{
+	margin: 0.5em 0;
+	list-style:none;
+	line-height:1.2em;
+}
+
+.bz-module ol.inner-toc {
+	margin-left:0;
+	list-style:none;
+}
+
+.bz-module .main-toc ol ol{
+	margin-left: 1.2em;
+}
+
+.bz-module .box-title {
+	margin: 0 0 0.5em;
+	text-align: left;
+	color: #222;
+}
+
+figcaption {
+	font-size: 16px;
+	color: #666;
+}
+
+.media-duration,
+.media-instructions,
+.toggle-transcript {
+	text-transform: uppercase;
+	font-size: 14px;
+	font-weight: normal;
+}
+
+.toggle-transcript {
+	color: #2E6D99;
+	cursor: pointer;
+}
+
+.transcript {
+	text-align: left;
+}
+
+.share-release {
+	font-size: 0.8em;
+	margin: 0.5em 0;
+	padding-bottom: 1em;
+	border-bottom: 1px solid #EEE;
+}
+
+input,
+textarea {
+	font-family: monospace;
+}
+
+.ref-source {
+	font-size: 50%;
+	vertical-align: super;
+	text-decoration: none;
+}
+
+.feedback.inline {
+	font-style: italic;
+	font-weight: normal;
+	color: #222;
+}
+
+blockquote {
+	margin: inherit;
+	color: #333;
+	padding: 20px;
+	border: 0;
+}
+
+.bz-module > div[data-replaced-with-page] > blockquote,
+.bz-module > blockquote {
+	background: bottom center no-repeat #D1AB5C;
+	background-image: url('images/bkg700-03.jpg');
+	position: relative;
+	margin: 3em 0;
+	width: calc( 100% - 6em );
+	padding: 3em;
+	font-style: italic;
+	font-size: 1.2em;
+	text-align: center;
+	color: #FFF;
+}
+
+.bz-module > div[data-replaced-with-page] > blockquote:nth-of-type(3n+0),
+.bz-module > blockquote:nth-of-type(3n+0) {
+	background-image: url('images/bkg700-02.jpg');
+}
+
+.bz-module > div[data-replaced-with-page] > blockquote:nth-of-type(3n+1),
+.bz-module > blockquote:nth-of-type(3n+1) {
+	background-image: url('images/bkg700-01.jpg');
+}
+blockquote.special:nth-of-type(5n+0) {
+  background-image: url('images/bkg-special-01.jpg');
+  background-position: center center;
+}
+blockquote.special:nth-of-type(5n+1) {
+  background-image: url('images/bkg-special-02.jpg');
+  background-position: center center;
+}
+blockquote.special:nth-of-type(5n+2) {
+  background-image: url('images/bkg-special-03.jpg');
+  background-position: center center;
+}
+blockquote.special:nth-of-type(5n+3) {
+  background-image: url('images/bkg-special-04.jpg');
+  background-position: center center;
+}
+blockquote.special:nth-of-type(5n+4) {
+  background-image: url('images/bkg-special-05.jpg');
+  background-position: center center;
+}
+
+.quote-source {
+	font-size: 75%;
+	margin: 1em 0;
+}
+
+blockquote .bz-hashtag {
+  color: #D7EFEF;
+}
+
+.quote-source:before {
+	content:"\2014 \00a0";
+}
+
+.bz-module > div[data-replaced-with-page] > p:not(.match-heading-style),
+.bz-module > p:not(.match-heading-style) {
+	margin: 3em 0;
+}
+
+.vignette {
+	border: 1px solid #333;
+	overflow-y: scroll;
+	height: 20em;
+}
+
+.vignette blockquote {
+	font-style: italic;
+}
+
+body:not(.student-logged-in) .tbd {
+	background: #FF0;
+}
+
+input[data-bz-retained="clicked"] {
+	background: #CCC !important;
+}
+
+.bz-inset {
+	padding: 2em;
+	background: #EEE;
+	text-align: center;
+}
+
+.pages.show .show-content {
+	padding: 15px;
+}
+
+.pages.show .page-title {
+	margin: 0 auto 30px;
+	color: #FFF;
+	background: #EB3B46;
+	padding: 3em;
+	text-align: center;
+}
+
+/* Progress bar */
+
+progress {
+	height: 5px;
+	/* Reset the default appearance */
+	-webkit-appearance: none;
+	-moz-appearence: none;
+	border: 0;
+	color: #008000;
+}
+
+progress[value]::-webkit-progress-bar {
+  background-color: #eee;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* Styling Canvas notifications */
+.ic-notification__icon {
+	background-color: #9ad7d7;
+}
+.ic-notification {
+	margin-top: 1em;
+	border: 0;
+	box-shadow: none;
+	border-radius: 0;
+}
+
+
+/* Hiding stuff the students don't need to see: */
+/* -------------------------------------------- */
+.student-logged-in #content .header-bar-outer-container,
+.student-logged-in .context-course_15 #content .header-bar-outer-container,
+.student-logged-in #quiz-time-elapsed,
+.student-logged-in #topbar #identity .inbox,
+.student-logged-in #menu #grades_menu_item,
+.student-logged-in #quiz-attributes-student,
+.student-logged-in #quiz_student_details,
+.student-logged-in div #quiz_show .alert,
+.student-logged-in .question .mce-toolbar-grp,
+.student-logged-in .question .mce-path,
+.hide-next-module-button .module-sequence-footer, /* this one depends on other factors on the page; the hide-next-button will be set by javascript */
+.student-logged-in #footer,
+.student-logged-in .bz-module-sequence-progress-container,
+.student-logged-in #bz-module-sequence-progress-bar {
+	display: none !important;
+}
+/*
+   can't just hide breadcrumbs;
+   need to keep this a certain height
+   to keep the sidebar from hiding under header
+*/
+.student-logged-in #breadcrumbs {
+	height: 28px;
+	border-bottom: none 0 !important;
+}
+.student-logged-in #breadcrumbs ul {
+	display: none;
+}
+.form-actions{
+	border: none;
+}
+/**/
+/* styles for alternative navigation */
+/* --------------------------------- */
+.bz-hide {
+	display: none;
+}
+
+/* Accessibility */
+/* ------------- */
+.says,
+.screen-reader-text,
+.screenreader-only {
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	width: 1px;
+	margin: 1px;
+	padding: 0;
+	overflow: hidden;
+	position: absolute !important;
+}
+
+
+/* Pick up where you left off */
+/* -------------------------- */
+#pick-up-where-you-left-off {
+  list-style: none; /* Assuming it has to be an li element. Otherwise delete this.*/
+}
+#pick-up-where-you-left-off .stream_header{
+  background: #EBF7F7;
+}
+#pick-up-where-you-left-off .stream_header:hover{
+  background: #D7EFEF;
+}
+#course_home_content #pick-up-where-you-left-off .stream_header .links {
+  display: block;
+}
+#pick-up-where-you-left-off .image-block-content {
+    font-family: "TradeGothicNo.20-CondBold", "Oswald", "Open Sans", sans-serif;
+    text-transform: uppercase;
+    line-height: normal;
+    font-weight: bold;
+    font-weight: 700;
+    font-size: 1.25em;
+
+}
+
+/*    Grades   */
+/* ----------- */
+
+.bz-gradebook-note {
+  padding: 1em;
+  margin-bottom: 1.1em;
+  background-color: #EBF7F7;
+  border: 1px solid #eee;
+}
+
+/* Help Button */
+/* ----------- */
+#bz-help-button {
+	position: fixed;
+	z-index: 99;
+	right: 0em;
+	bottom: 33%;
+	font-size: 12pt;
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", "Open Sans", sans-serif;
+	text-transform: uppercase;
+	line-height: normal;
+	font-weight: bold;/* fallback */
+	font-weight: 700;
+	margin: 0px;
+	padding: 0px;
+}
+
+#bz-help-button a {
+	display: block;
+
+	transform: rotate(270deg);
+	transform-origin: 100% 100%;
+	-ms-transform: rotate(270deg);
+	-ms-transform-origin: 100% 100%;
+	-webkit-transform: rotate(270deg);
+	-webkit-transform-origin: 100% 100%;
+	-moz-transform: rotate(270deg);
+	-moz-transform-origin: 100% 100%;
+
+	margin: 0px;
+
+	padding: 0.5em 0.8em;
+	background-color: #EB3B46;
+	/*border-radius: 6px 6px 0px 0px;*/
+	border: none;
+	border-bottom: none;
+	text-decoration: none;
+	color: white;
+}
+#bz-help-button a:active,
+#bz-help-button a:visited,
+#bz-help-button a:link  {
+	color: #FFF;
+}
+#bz-help-button a:hover,
+.bz-course-part-module-box .bz-button-pick-up:hover {
+	text-decoration: none;
+	background: #C8141F;
+}
+
+.bz-course-part-task-box .todo-details p:nth-of-type(1) {
+	font-weight: bold;
+}
+
+#bz-tz-warning {
+	position: fixed;
+	top: 0px;
+	left: 30%;
+	width: 40%;
+	background-color: #ffff88;
+	padding: 4px;
+	box-sizing: border-box;
+	z-index: 20;
+	border: solid 1px #ccc;
+	border-radius: 0px 0px 4px 4px;
+	text-align: center;
+}
+
+.bz-rsvps {
+	max-height: 8em; /* fallback if vh doesn't work */
+	max-height: 25vh; /* 25% of the screen height */
+	overflow: auto;
+}
+
+/* no reply yet at all */
+.bz-rsvps dt[data-response-status="needsAction"]::before {
+	content: '? ';
+	color: grey;
+	font-style: italic;
+}
+
+.bz-rsvps dt[data-response-status="declined"]::before {
+	content: 'X ';
+	color: red;
+}
+
+
+/* means they replied with a "maybe" answer */
+.bz-rsvps dt[data-response-status="tentative"]::before {
+	content: '? ';
+	color: #cc8800;
+}
+
+
+.bz-rsvps dt[data-response-status="accepted"]::before {
+	content: '\2713\a0'; /* check box */
+	color: green;
+}
+
+.bz-rsvps dd {
+	display: none;
+}
+
+#bz-retained-field-dialog-holder {
+    position: fixed;
+    left: 0px;
+    top: 0px;
+    right: 0px;
+    bottom: 0px;
+    background-color: rgba(0, 0, 0, 0.8);
+    z-index: 500;
+}
+
+#bz-retained-field-dialog {
+    position: fixed;
+    left: 10vw;
+    right: 10vw;
+    top: 10vh;
+    bottom: 10vh;
+    background-color: white;
+    padding: 2em;
+    box-sizing: border-box;
+}
+
+#bz-retained-field-dialog label {
+    display: block
+}
+
+#bz-retained-field-dialog label > span {
+    width: 10em;
+    display: inline-block;
+    text-align: right;
+    font-weight: bold;
+}
+
+#bz-retained-field-dialog .cancel {
+    margin-left: 10em;
+    margin-right: 3em;
+}
+
+#bz-retained-field-dialog .bz-dialog-header {
+    font-weight: bold;
+    margin-bottom: 2em;
+    border-bottom: solid 2px #333;
+    font-size: 16px;
+}
+
+/* Module nav in sidebar */
+/* --------------------- */
+#bz-module-nav {
+	display: none;
+}
+
+/* Dynamic Syllabus components */
+
+.bz-dynamic-syllabus {
+
+}
+
+.bz-dynamic-syllabus h1 {
+  color: #ee2640;
+  font-size: 2em;
+}
+
+.bz-dynamic-syllabus .bz-course-intro-text p {
+  font-style: italic;
+}
+
+.bz-dynamic-syllabus .bz-course-part > p {
+  font-style: italic;
+}
+
+.bz-course-part {
+  border-left: solid 8px black;
+  padding-left: 8px;
+	margin: 20px 0px;
+}
+
+.bz-course-part-module-box div p {
+	font-size: 16px;
+}
+
+.bz-course-part > .textbox,
+.bz-course-part > h2 {
+	padding-left: 10px;
+}
+
+.bz-course-part:nth-child(4n+0) {
+	/* Sky */
+	border-left-color: #9AD7D7;
+}
+
+.bz-course-part:nth-child(4n+2) {
+	/* Gold */
+	border-left-color: #D1AB5C;
+}
+
+.bz-course-part:nth-child(4n+3) {
+	/* Red */
+	border-left-color: #EB3B46;
+}
+
+.bz-course-part.bz-part-collapsed .bz-expand-collapse-button ~ * {
+  display: none;
+}
+
+.bz-course-part-task-box {
+  padding: 0px;
+  margin: 10px 0;
+  background-color: #EEE;
+  overflow-y: auto;
+  height: 200px;
+	font-family: Oswald, "Arial Narrow", sans-serif;
+}
+
+.bz-course-part-task-box .course-options {
+  float: right;
+  width: 25%;
+  box-sizing: border-box;
+}
+
+.bz-course-part-task-box .course-options .btn {
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  margin-bottom: 4px;
+}
+
+.bz-course-part-task-box #course_show_secondary,
+.bz-course-part-task-box .events_list {
+  box-sizing: border-box;
+  width: 25%;
+  float: left;
+  vertical-align: top;
+  margin: 0px;
+  padding: 8px;
+}
+
+.student-logged-in .bz-course-part-task-box #course_show_secondary,
+.student-logged-in .bz-course-part-task-box .events_list {
+  width: 33.3%;
+}
+
+.student-logged-in .bz-course-part-task-box .course-options {
+  display: none;
+}
+
+
+.bz-course-part-task-box #course_show_secondary h2,
+#content .bz-course-part-task-box .events_list h2 {
+  font-size: 1rem !important;
+}
+
+.bz-course-part-task-box .event-list-view-calendar {
+  float: right;
+  font-weight: normal;
+	color: #EB3B46;
+}
+
+.event-list-view-calendar:visited {
+	color: #EB3B46;
+}
+
+.event-list-view-calendar:hover,
+.event-list-view-calendar:active {
+	color: #C8141F;
+}
+
+.bz-course-part-task-box::after {
+  clear: both;
+  display: block;
+  content: '\a0';
+}
+
+.bz-course-part-task-box ul {
+  margin-left: 0;
+  list-style: outside none;
+}
+
+.bz-course-part-task-box li p,
+.bz-course-part-task-box li .event-details,
+.bz-course-part-task-box .item > * {
+  display: inline;
+}
+
+.bz-course-part-task-box .todo {
+  margin: 0 10px 10px 0;
+  position: relative;
+}
+
+.bz-course-part-task-box .IgnoreButton {
+  position: absolute;
+  right: -30px;
+  top: 0;
+  padding: 5px;
+}
+
+.bz-course-part-task-box .events_list .event {
+	margin: 5px 0;
+}
+
+.bz-course-part-module-box {
+  display: inline-block;
+  width: 220px;
+  height: 400px;
+  padding: 10px;
+	margin: 20px 10px 0;
+	background-color: #EEE;
+  vertical-align: top;
+  position: relative;
+}
+
+.bz-course-part-module-box:hover::after {
+  display: none !important; /* the important means i don't have to do specificity on EVERY hover after for the classes too */
+}
+
+.bz-course-part-module-box.completed::after,
+.bz-course-part-module-box.locked::after {
+  background-position: top center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  content: "\a0";
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  display: block;
+  background-color: #eee;
+  background-color: rgba(250, 250, 250, 0.8);
+}
+
+.bz-course-part-module-box.completed::after {
+  background-image: url("dynamic-syllabus-icons-completed.png");
+}
+
+.bz-course-part-module-box.locked::after {
+  background-image: url("dynamic-syllabus-icons-locked.png");
+}
+
+.bz-course-part-module-box .bz-module-image {
+  display: block;
+  padding: 0px;
+  height: 200px;
+  text-align: center;
+	margin-top: 10px;
+}
+
+.bz-course-part-module-box .bz-module-image img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.bz-course-part-module-box .bz-button-pick-up {
+  display: block;
+  text-align: center;
+  text-transform: uppercase;
+  background-color: #ee2640;
+  color: white;
+  font-weight: bold;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 30px;
+}
+
+.bz-course-part-module-box.completed .bz-button-pick-up {
+  color: #FFF;
+  background-color: green;
+}
+
+.bz-course-part-module-box .bz-button-pick-up::before {
+  content: "\a0";
+  background-repeat: no-repeat;
+  background-size: contain;
+  display: inline-block;
+  height: 2em;
+  width: 1px;
+  vertical-align: middle;
+}
+
+.bz-expand-collapse-button {
+	border: none;
+	background: #EB3B46;
+	color: #FFF;
+	padding: 6px 10px;
+}
+
+.bz-expand-collapse-button:hover {
+	background: #C8141F;
+}
+
+.bz-dynamic-syllabus-editor {
+
+}
+
+.bz-dynamic-syllabus-editor label {
+  display: block;
+}
+
+.bz-dynamic-syllabus-editor label > span {
+  display: block;
+  font-weight: bold;
+}
+
+/* Customizing the modules list view */
+/* --------------------------------- */
+#context_modules {
+	font-family: sans-serif;
+}
+
+/* Customize modules list to remove ellipsis */
+#context_modules .ig-title {
+	flex: 0 0 65%;
+}
+
+#context_modules .ig-title,
+#context_modules .ig-header-title {
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", "Open Sans", sans-serif;
+	font-size: 1.2em;
+}
+.context_module_item .item_name .title {
+	font-size: 16px !important;
+}
+#context_modules .ig-header-title {
+	text-transform: uppercase;
+}
+#context_modules .ig-header-title .name {
+	font-size: 1.4em;
+}
+.indent_0 {
+	text-transform:uppercase;
+}
+
+/* TOOLTIP: */
+.bz-tooltip {
+	display:none;
+	position:absolute;
+	border:1px solid #333;
+	background-color:#161616;
+	border-radius:5px;
+	padding:10px;
+	color:#fff;
+	font-size:12px;
+	margin: 2em;
+}
+
+.bz-uses-tooltips {
+	position: relative;
+	margin-right: auto;
+}
+
+.bz-has-tooltip {
+	border-bottom: 2px dotted #5bbbba;
+	cursor: pointer; /* fallback */
+	cursor: help;
+}
+
+.ui-widget.ui-tooltip {
+	font-size: 13px;
+}
+/* Hide tooltip arrow */
+.ui-tooltip::before {
+ display: none;
+}
+
+/* LAYOUT */
+html {
+	/* prevent jump when new content is revealed */
+  overflow-y: scroll;
+}
+
+.bz-module,
+.bz-view-box {
+	width: 672px;
+	position: relative;
+}
+
+.bz-module {
+	margin: 0px;
+	margin-bottom: 200px;
+	/* margin: 0 auto 200px; */
+	position: relative;
+}
+
+.bz-module .roll-back-left {
+	margin-left: -200px !important;
+}
+
+.bz-view-box {
+	overflow-x: auto;
+}
+
+.module-block .bz-view-box {
+	left: -60px;
+}
+
+/*.module-block {
+	padding: 60px;
+	padding-right: 0;
+	border-top: 1px solid #CCC;
+	border-bottom: 1px solid #CCC;
+	margin-bottom:-1px;
+}*/
+
+.bz-module  .module-block h3 {
+	margin-top:0;
+}
+
+figcaption {
+	margin: 15px auto;
+	text-align: center;
+}
+
+.centered {
+	text-align: center;
+}
+
+.conditional-show {
+	display: none;
+}
+
+#wiki_page_show table td,
+#wiki_page_show table th,
+.bz-magic-field-assignment .bz-regular td,
+.bz-magic-field-submission .bz-regular td,
+.bz-magic-field-assignment .bz-regular th,
+.bz-magic-field-submission .bz-regular th {
+	border: 1px solid #eee;
+	padding: 0.3em 0.5em !important;
+}
+
+.checklist,
+.radio-list {
+	list-style:none outside;
+	padding-left: 0;
+	margin-left: 0;
+}
+
+.revealable,
+.feedback {
+	display: none;
+}
+
+.show-answers .feedback {
+	display: block;
+}
+
+.show-answers.correct {
+	color: #22B573;
+}
+
+ tr:not(.suppress-answers) td.show-answers.correct {
+ background: #22B573;
+ color: #FFF;
+}
+
+.show-answers.maybe,
+ul:not(.instant-feedback) .show-answers.correct:not(.checked) {
+  color: #B08833;
+}
+
+ tr:not(.suppress-answers) td.show-answers.maybe {
+ background: #B08833;
+}
+
+.show-answers.incorrect,
+ul:not(.instant-feedback) .show-answers.checked:not(.correct) {
+  color: #EB3B46;
+}
+
+tr:not(.suppress-answers) td.show-answers.incorrect {
+  background: #EB3B46;
+  color: #FFF;
+}
+
+.feedback.inline {
+    padding: 10px;
+    background: #EEE;
+    margin: 0.5em 0 1em;
+}
+
+.display-value {
+	text-align: center;
+}
+
+.checklist,
+.radio-list {
+	padding-left: 0;
+}
+
+.checklist li,
+.radio-list li {
+	position: relative;
+	margin: 0.5em 0;
+	padding-left: 2em;
+}
+
+.checklist [type='checkbox'],
+.radio-list:not(.multi-radios) [type='radio'],
+.bz-has-other [type='checkbox'],
+.bz-has-other [type='radio'] {
+	position: absolute;
+	left: 0;
+}
+
+.share-release [type='checkbox'] {
+	position: static;
+	height: 0.8em;
+}
+
+.radio-list {
+	list-style: none;
+}
+
+input[type="button"] {
+	border:none;
+	background: #EB3B46;
+	color: #FFF;
+}
+
+.module-block input[type="button"] {
+    margin: 20px 0;
+}
+
+input[type="button"]:hover {
+	background: #C8141F;
+}
+
+input[type="button"]:active {
+	background: #EB3B46;
+}
+
+input[type='button']:disabled {
+	background: #CCC;
+	color: #666;
+}
+
+.bz-module input[type='text'],
+.bz-module input[type='url'],
+.bz-module input[type='number'],
+.bz-module textarea {
+	background: #F6EFDF;
+	padding: 10px;
+	border: 1px solid #CCC;
+}
+
+.bz-module input[type='text'],
+.bz-module input[type='url'] {
+	min-width: 33%;
+}
+
+.bz-graded-question:before {
+  content: "MASTERY Q";
+  color: #EB3B46;
+  margin-right: 0.25em;
+  text-transform: uppercase;
+  background: white;
+  padding: 0 4px;
+  border: 2px solid #EB3B46;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.user_content table:not([cellpadding]) td,
+.mceContentBody table:not([cellpadding]) td {
+	padding: 10px;
+}
+
+/*
+input[type='button'].add-other-field {
+	font-size: 16px;
+	padding: 5px 8px;
+}
+*/
+
+.question,
+.answer,
+.reflection,
+.video,
+.pulse,
+.alert,
+.key,
+.action,
+.values,
+.read,
+.video .box-title,
+.flush .box-title {
+	padding-left: 60px;
+	background: 0px 50px no-repeat;
+	position: relative;
+	color: inherit;
+}
+
+.video,
+.flush {
+	padding-left: 0;
+}
+
+figure {
+	margin: 30px 0;
+	text-align: center;
+}
+
+.media-duration,
+.media-instructions {
+	display: block;
+	margin: 10px;
+}
+
+.question {
+	background-image: url('images/lms-icons-04.png');
+}
+
+.question.survey-question {
+	/* Don't want question image on retro survey */
+	background-image: none;
+}
+
+.answer {
+	background-image: url('images/lms-icons-100.png');
+}
+
+.answer.correct {
+	background-image: url('images/lms-icons-99.png');
+}
+
+.bz-module .answer.correct .box-title {
+	color: #22B573;
+}
+
+.answer.incorrect {
+	background-image: url('images/lms-icons-98.png');
+}
+
+.bz-module .answer.incorrect .box-title {
+	color: #C1272D;
+}
+
+.reflection {
+	background-image: url('images/lms-icons-14.png');
+}
+
+.video {
+	background-image: url('images/lms-icons-23.png');
+}
+
+.pulse {
+	background-image: url('images/lms-icons-30.png');
+}
+
+.alert {
+	background-image: url('images/lms-icons-11.png');
+}
+
+.key {
+	background-image: url('images/lms-icons-33.png');
+}
+
+.action {
+	background-image: url('images/lms-icons-41.png');
+}
+
+.values {
+	background-image: url('images/lms-icons-47.png');
+}
+
+.read {
+	background-image: url('images/lms-icons-read-56.png');
+}
+li input:not([type="button"]):not([type="radio"]):not([type="checkbox"]), li textarea {
+ margin: 0.5em;
+}
+
+.full {
+	width: 100%;
+	height: auto;
+	margin: 0 auto;
+}
+
+.two-thirds {
+	width: 66%;
+	height: auto;
+	margin: 2em 17%;
+	text-align: center;
+}
+
+.shrink {
+	font-size: 0.8em;
+}
+
+.to-columns {
+	-webkit-column-count: 3;
+	-moz-column-count: 3;
+	-ms-column-count: 3;
+	column-count: 3;
+	-webkit-column-gap: 10px;
+	-moz-column-gap: 10px;
+	-ms-column-gap: 10px;
+	column-gap: 10px;
+}
+
+.to-columns li {
+	margin: 0;
+	display: inline-block;
+	padding: 0.75em 0.75em 0.75em 1.5em;
+	-webkit-column-break-inside: avoid;
+	page-break-inside: avoid;
+	break-inside: avoid;
+}
+
+#wiki_page_show table:not(.no-zebra):not(.sort-to-match) tr:nth-child(even):not(.no-zebra),
+.to-columns li:nth-child(even) {
+ background: #F6F6F6;
+}
+
+table {
+	border-collapse: collapse;
+}
+
+.module-block figure iframe {
+	width: 672px;
+	height: 378px;
+}
+
+.module-block:not(.video):not(.flush) figure iframe {
+	width: 612px;
+	height: 344px;
+}
+
+iframe {
+	border: none;
+	outline: none;
+}
+
+figcaption {
+	width: 66%;
+	margin: 0.5em 17%;
+}
+
+.module-block textarea {
+	width: calc( 100% - 2em );
+	height: 5em;
+}
+
+.user_content table:not([cellpadding]) {
+	margin-left: 0;
+	border-collapse: collapse;
+}
+
+td,
+th {
+	padding: 0.75em;
+	border: 1px solid #CCC;
+}
+.sortable td:not(.unsortable) {
+ border: 1px solid #CCC;
+ cursor: pointer;
+}
+
+.tip {
+}
+
+.sort-to-match thead,
+.sort-to-match .fixed {
+	cursor: inherit;
+}
+
+/* Assorted anecdotal styles we didn't want to put inline: */
+#bz-values-matrix {
+	border-collapse: collapse;
+}
+
+#bz-values-matrix td {
+	cursor: pointer;
+	padding: 5px;
+	border: 1px solid #DDD;
+	margin: 0;
+	height: 3em;
+	text-align: center;
+	font-size: 15px;
+	letter-spacing: 0.02em;
+}
+
+.inner-checked {
+	background: #D7EFEF;
+}
+
+#match-course-parts tbody td:first-child {
+	text-align: center;
+	width: 50%;
+}
+
+#match-course-elements td:first-child {
+	width: 33%;
+}
+
+#comms-options td:not(:first-child) {
+	text-align: center;
+}
+
+#comms-options {
+	font-size: 0.8em;
+	float:left;
+	clear: both;
+	margin-bottom: 20px;
+}
+
+#designers {
+	font-size: 0.8em;
+}
+
+#goals-vs-vision td {
+	text-align: center;
+}
+
+#goals-vs-vision tr:first-child td {
+	height: 180px;
+	overflow: hidden;
+}
+
+#goals-vs-vision img {
+	width: 100%;
+}
+
+#goals-smart {
+	table-layout: fixed;
+	width: 100%;
+}
+
+#goals-smart td {
+	text-align: center;
+	width: 10%;
+}
+
+#goals-smart td:first-child {
+	text-align: left;
+	font-style: italic;
+}
+
+#goals-smart th:first-child {
+	width: 50% !important;
+}
+
+.from-slideshare {
+	width: 672px;
+	height: 427px;
+	border: 1px #CCC solid;
+	margin-bottom:5px;
+	max-width: 100%;
+}
+
+#match-smart-example tr:first-child {
+	border: 2px solid #666;
+}
+ #match-smart-example tr.correct:not(:first-child), #match-smart-example tr.incorrect:not(:first-child) {
+ background: none;
+}
+
+.instant-range-feedback {
+	width: 100%;
+}
+
+.instant-range-feedback .feedback {
+	display: none;
+}
+
+.inputs-row {
+	text-align: center;
+}
+
+table [type="range"] {
+	width: 100%;
+	padding: 0;
+}
+
+#rubric-demo table *:hover {
+	background: #F6F6F6;
+}
+
+#rubric-demo,
+#criteria-demo,
+#max-score-demo,
+#expectation-demo {
+	position: relative;
+}
+
+#criteria-demo:after,
+#max-score-demo:after,
+#expectation-demo:after {
+	content: '1';
+	display: block;
+	position: absolute;
+	width: 20px;
+	height: 20px;
+	background: #EB3B46;
+	padding: 5px;
+	text-align: center;
+	color: #FFF;
+	font-family: sans-serif;
+	left: 5px;
+	top: 5px;
+	font-weight: bold;
+	border-radius: 20px;
+}
+
+#criteria-demo:after {
+	content: '2';
+	left: calc( 25% - 10px );
+	top: 5px;
+}
+
+#max-score-demo:after {
+	content: '3';
+	left: -32px;
+	bottom: 10px;
+}
+
+.diagram-legend {
+	counter-reset: legend-counter;
+	list-style: none;
+}
+
+.diagram-legend li {
+	margin: 0.5em;
+	position: relative;
+}
+
+.diagram-legend li:before {
+    content: counter(legend-counter);
+    counter-increment: legend-counter;
+    position: absolute;
+    left: -1.5em;
+    display: block;
+    width: 20px;
+    height: 20px;
+    background: #EB3B46;
+    text-align: center;
+    font-weight: bold;
+    font-family: sans-serif;
+    color: #FFF;
+    border-radius: 20px;
+    font-size: 0.9em;
+}
+
+#expectations-aligned-w-reasons thead th:first-child {
+	 width: 20%;
+}
+
+#expectations-aligned-w-reasons thead th:nth-child(2) {
+	 width: 40%;
+}
+
+#expectations-aligned-w-reasons * {
+	font-size: 80%;
+}
+
+.checklist-other {
+	margin: 1em 0;
+}
+
+.bz-has-other {
+	padding-left: 2em;
+	position: relative;
+}
+
+.equal-column-widths {
+	table-layout: fixed
+}
+
+.equal-column-widths td {
+	width: 1%;
+}
+
+.auto-image-widths img {
+	width: 100%;
+	height: auto;
+}
+
+#wrapper {
+	background: #fff;
+}
+
+#bz-back-to-top {
+    display: none;
+    opacity: 0.75;
+    position: fixed;
+    text-align: center;
+    margin: 0 auto;
+    font-size: 14px;
+    color: #666;
+    bottom: 0;
+    right: 0;
+    cursor: pointer;
+    width: 100%;
+    left: 0;
+    background: #fff;
+    padding: 10px 0;
+
+}
+
+#bz-back-to-top:hover {
+	color: #EB3B46;
+  opacity: 1;
+
+}
+
+.bz-resume-box * {
+    font-family: "Times New Roman", Times, serif;
+    letter-spacing: -0.2px;
+    font-size: 14px;
+    background: #FFF;
+}
+
+.bz-resume-box .resume-title {
+	text-align: center;
+	font-size: 30px;
+}
+
+.bz-resume-box .resume-contact-info {
+	text-align: center;
+}
+
+.bz-resume-box td {
+    border: 0 !important;
+}
+
+.bz-resume-box .resume-section {
+    font-size: 20px;
+    font-weight: bold;
+    font-style: italic;
+    border-bottom: 1px #000 solid !important;
+}
+
+.bz-resume-box .resume-when,
+.bz-resume-box .resume-where {
+    font-weight: bold;
+    font-size: 14px;
+    padding-top: 5px;
+}
+
+.bz-resume-box li {
+    margin: 0 !important;
+}
+
+.for-range,
+.for-checklist,
+.instant-feedback,
+.bz-toggle-all-next {
+/* TBD */
+}
+
+/* Show Resources Briefcase as list of icons */
+.bz-icons-list {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    width: 100%;
+    margin: 30px 0 0;
+    padding: 0;
+}
+
+.bz-icons-list li {
+    box-sizing: border-box;
+    display: block;
+    width: 25%;
+    padding: 0.5em;
+    padding-top: 120px;
+    text-align: center;
+    position: relative;
+}
+
+.bz-icons-list a {
+    text-decoration: none;
+}
+
+.bz-icons-list a::before,
+.bz-icon-inline::before {
+    content: ' ';
+    background-color: #9AD7D7;
+    width: 100px;
+    height: 100px;
+    border-radius: 50px;
+    position: absolute !important;
+    top: 0;
+    background-image: url('images/lms-resources-icons.png?date=020119');
+}
+
+.bz-icons-list a::before {
+    left: calc( (100% - 100px) / 2 );
+}
+
+.bz-icon-inline {
+    position: relative;
+    padding-left: 30px;
+}
+
+.bz-icon-inline::before {
+    left: 2px;
+    transform: scale(0.23);
+    transform-origin: 0 0;
+}
+
+.bz-icons-list a:hover::before {
+    background-color: #5BBBBA;
+}
+
+.bz-icon-smart-goals::before,
+[href~='pages/1-1-coaching-conversations-with-your-leadership-coach'] {
+    background-position: 0 -100px;
+}
+
+.bz-icon-1on1::before,
+[href~='pages/smart-goals'] {
+    background-position: 0 -200px;
+}
+
+.bz-icon-apply-game::before {
+    background-position: 0 -300px;
+}
+
+.bz-icon-linkedin::before,
+[href~='pages/write-a-strong-linkedin-summary-statement'] {
+    background-position: 0 -400px;
+}
+
+.bz-icon-email::before,
+[href~='pages/write-great-emails'] {
+    background-position: 0 -500px;
+}
+
+.bz-icon-icebreakers::before,
+[href~='pages/conversation-starters-for-networking-events'] {
+    background-position: 0 -600px;
+}
+
+.bz-icon-elevator::before,
+[href~='pages/elevator-pitch-template'] {
+    background-position: 0 -700px;
+}
+
+.bz-icon-questions::before,
+[href~='pages/informational-interview-questions-list'] {
+    background-position: 0 -800px;
+}
+
+.bz-icon-champion::before {
+    background-position: 0 -900px;
+}
+
+.bz-icon-resume-writing::before {
+    background-position: 0 -1000px;
+}
+
+.bz-icon-resume-bank::before,
+[href~='pages/resume-and-cover-letter-bank'] {
+    background-position: 0 -1100px;
+}
+
+.bz-icon-more-resources::before,
+[href~='pages/recommended-resources-for-your-opportunity-hunt'] {
+    background-position: 0 -1200px;
+}
+
+.bz-icon-scorecard::before,
+[href~='pages/rank-opportunities-with-the-career-accelerating-scorecard'] {
+    background-position: 0 -1300px;
+}
+
+.bz-icon-interview::before,
+[href~='pages/interview-response-frameworks'] {
+    background-position: 0 -1400px;
+}
+
+.bz-icon-technical-iv::before,
+[href~='pages/technical-interviews-for-software-engineers-and-computer-scientists'] {
+    background-position: 0 -1500px;
+}
+
+.bz-icon-design-thinking::before,
+[href~='pages/design-thinking'] {
+    background-position: 0 -1600px;
+}
+
+.bz-icon-finance::before,
+[href~='pages/personal-finance'] {
+    background-position: 0 -1700px;
+}
+
+.bz-icon-excel::before,
+[href~='pages/excel'] {
+    background-position: 0 -1800px;
+}
+
+.bz-icon-site-visit::before,
+[href~='pages/site-visit-professionalism'] {
+    background-position: 0 -1900px;
+}
+
+.bz-icon-resources::before,
+[href~='pages/braven-resources'] {
+    background-position: 0 -2000px;
+    background-color: #EB3B46 !important;
+}
+
+.bz-icon-handshake::before,
+[href~='pages/handshake-tips'] {
+    background-position: 0 -2100px;
+}
+
+.bz-icon-briefcase::before {
+    background-position: 0 -2200px;
+}
+
+/* Styling for quizzes/assignments that use magic fields to layout complex content */
+
+.btn, .Button--primary {
+	border: 0;
+	/*border-radius: 0;*/
+}
+.btn-primary, .Button--primary {
+	background: #eb3b46;
+}
+.btn-primary:hover, .Button--primary:hover {
+	background: #c8141f;
+}
+.btn-secondary {
+	background: #9ad7d7;
+}
+
+.btn-secondary:hover {
+	background: #ebf7f7;
+}
+
+#questions,
+.quiz-submission,
+.discussions #main {
+	background: #ebf7f7 !important;
+}
+
+.toolbarView#discussion-toolbar .headerBar {
+	background: #D7EFEF !important;
+}
+
+.question_holder .display_question .file-upload-question-holder .file-upload-box {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.bz-magic-field-assignment h3,
+.bz-magic-field-submission h3 {
+	font-size: 30px;
+	color: #EB3B46;
+	margin-top: 3em;
+	padding-top: 1em;
+	border-top: 1px solid #CCC;
+}
+
+.bz-magic-field-assignment h4,
+.bz-magic-field-submission h4 {
+	font-size: 26px;
+	margin-top: 1.5em;
+	color: #222;
+}
+
+.bz-magic-field-assignment h5,
+.bz-magic-field-submission h5 {
+	font-size: 22px;
+}
+
+.bz-magic-field-assignment h6,
+.bz-magic-field-submission h6 {
+	font-size: 18px;
+}
+
+.bz-magic-field-assignment .bz-inputs-table input,
+.bz-magic-field-submission .bz-inputs-table input {
+	width: calc(100% - 20px);
+}
+
+.bz-magic-field-assignment textarea[data-bz-retained],
+.bz-magic-field-submission textarea[data-bz-retained] {
+	width: calc(100% - 20px);
+	height: 3em;
+}
+
+
+.bz-magic-field-assignment table.narrow,
+.bz-watch-out-box,
+.bz-helpful-tip-box,
+.bz-example {
+	width: 67%;
+	padding: 20px;
+	margin: 1em auto;
+	border: 5px solid;
+}
+
+.bz-watch-out-box {
+	border-color: #EB3B46;
+}
+
+.bz-helpful-tip-box {
+	border-color: #9AD7D7;
+}
+
+.bz-example {
+	border-color: #FBFBFB;
+  width: calc(100% - 50px);
+}
+
+.bz-magic-field-assignment table.steps td,
+.bz-magic-field-submission table.steps td,
+.bz-magic-field-assignment table.steps th,
+.bz-magic-field-submission table.steps th,
+.bz-magic-field-assignment table.bz-inputs-table th,
+.bz-magic-field-submission table.bz-inputs-table th,
+.bz-magic-field-assignment table.bz-inputs-table td,
+.bz-magic-field-submission table.bz-inputs-table td {
+	vertical-align: middle;
+	text-align: left;
+	padding: 10px;
+	border: 1px solid #EEE;
+}
+
+.bz-magic-field-assignment li,
+.bz-magic-field-submission li {
+	margin: 0.5em 0;
+}
+
+.bz-magic-field-assignment iframe.rubric,
+.bz-magic-field-submission iframe.rubric {
+	width: 100%;
+	height: 300px;
+	border: 2px solid #000;
+}
+
+.bz-magic-field-assignment iframe.rubric #main,
+.bz-magic-field-submission iframe.rubric #main {
+	width: 100% !important;
+}
+
+.bz-magic-field-assignment iframe.rubric #bz-help-button,
+.bz-magic-field-submission iframe.rubric #bz-help-button {
+	display: none !important;
+}
+
+.bz-magic-field-assignment iframe.rubric body,
+.bz-magic-field-submission iframe.rubric body,
+.bz-magic-field-assignment iframe.rubric .with-right-side.with-left-side,
+.bz-magic-field-submission iframe.rubric .with-right-side.with-left-side,
+.bz-magic-field-assignment iframe.rubric .with-right-side,
+.bz-magic-field-submission iframe.rubric .with-right-side,
+.bz-magic-field-assignment iframe.rubric .with-left-side,
+.bz-magic-field-submission iframe.rubric .with-left-side {
+	min-width: 0 !important;
+	width: 100% !important;
+}
+
+.bz-magic-field-assignment iframe.rubric .with-right-side #main,
+.bz-magic-field-submission iframe.rubric .with-right-side #main,
+.bz-magic-field-assignment iframe.rubric .with-left-side #main,
+.bz-magic-field-submission iframe.rubric .with-left-side #main {
+	margin-right: 0 !important;
+	margin-left: 0 !important;
+}
+
+.bz-assignment p,
+.bz-assignment li {
+  margin-bottom: 1em;
+  line-height: 1.3;
+}
+
+.bz-assignment {
+  margin: 2em auto;
+  width: 672px;
+}
+
+.bz-assignment-intro {
+  background: #EBF7F7;
+  padding: 2em;
+  margin: 2em auto;
+}
+
+.bz-assignment .bz-helpful-tip-box,
+.bz-assignment .bz-watch-out-box,
+.bz-assignment .bz-example,
+.bz-assignment p textarea {
+  width: calc(100% - 4em - 10px);
+  background: white;
+  padding: 2em;
+  margin: 2em auto;
+}
+
+/* Generic toggle link for (un)collapsing the parent element (with associated JS) */
+
+.bz-toggle-collapse {
+    cursor: pointer;
+    text-decoration: underline;
+    color: #0081bd;
+}
+
+/* Timline */
+.bz-magic-field-assignment .timeline,
+.bz-magic-field-submission .timeline {
+	position: relative;
+	width: 480px;
+	margin: 20px auto;
+	padding: 20px 0;
+	list-style: none;
+}
+
+.bz-magic-field-assignment .timeline:before,
+.bz-magic-field-submission .timeline:before {
+	/* the vertical line */
+  position: absolute;
+	left: 50%;
+	top: 0;
+	content: ' ';
+	display: block;
+	width: 6px;
+	height: 100%;
+	margin-left: -3px;
+	background: rgb(80,80,80);
+	background: -moz-linear-gradient(top, rgba(80, 80, 80, 0) 0%, rgb(80,80,80) 8%, rgb(80,80,80) 92%, rgba(80, 80, 80, 0) 100%);
+	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, rgba(30, 87, 153, 1)), color-stop(100%, rgba(125, 185, 232, 1)));
+	background: -webkit-linear-gradient(top, rgba(80, 80, 80, 0) 0%, rgb(80,80,80) 8%, rgb(80,80,80) 92%, rgba(80, 80, 80, 0) 100%);
+	background: -o-linear-gradient(top, rgba(80, 80, 80, 0) 0%, rgb(80,80,80) 8%, rgb(80,80,80) 92%, rgba(80, 80, 80, 0) 100%);
+	background: -ms-linear-gradient(top, rgba(80, 80, 80, 0) 0%, rgb(80,80,80) 8%, rgb(80,80,80) 92%, rgba(80, 80, 80, 0) 100%);
+	background: linear-gradient(to bottom, rgba(80, 80, 80, 0) 0%, rgb(80,80,80) 8%, rgb(80,80,80) 92%, rgba(80, 80, 80, 0) 100%);
+}
+
+.bz-magic-field-assignment .timeline li:after,
+.bz-magic-field-submission .timeline li:after {
+	/* clearfix for floats */
+  content: "";
+	display: block;
+	height: 0;
+	clear: both;
+	visibility: hidden;
+}
+
+.bz-magic-field-assignment .timeline .milestone,
+.bz-magic-field-submission .timeline .milestone {
+	position: relative;
+	width: 210px;
+	float: left;
+	text-align: right;
+}
+ .bz-magic-field-assignment .timeline li:nth-child(even) .milestone,
+ .bz-magic-field-submission .timeline li:nth-child(even) .milestone {
+ float: right;
+}
+
+.bz-magic-field-assignment .timeline .flag-wrapper,
+.bz-magic-field-submission .timeline .flag-wrapper {
+	position: relative;
+	text-align: center;
+	background: none;
+}
+
+.bz-magic-field-assignment .timeline .flag-wrapper:before,
+.bz-magic-field-submission .timeline .flag-wrapper:before {
+	position: absolute;
+	top: 50%;
+	right: -40px;
+	content: ' ';
+	display: block;
+	width: 12px;
+	height: 12px;
+	margin-top: -10px;
+	background: #fff;
+	border-radius: 10px;
+	border: 4px solid #EB3B46;
+	z-index: 10;
+}
+
+.bz-magic-field-assignment .timeline .milestone.first flag-wrapper:before,
+.bz-magic-field-submission .timeline .milestone.first flag-wrapper:before {
+	border-color: #CCC;
+}
+ .bz-magic-field-assignment .timeline li:nth-child(even) .flag-wrapper:before, .bz-magic-field-submission .timeline li:nth-child(even) .flag-wrapper:before {
+ left: -40px;
+}
+
+.bz-magic-field-assignment .timeline .desc,
+.bz-magic-field-submission .timeline .desc {
+	margin: 10px;
+	font-style: italic;
+	line-height: 1.5em;
+}
+
+.bz-magic-field-assignment .timeline .milestone.final textarea,
+.bz-magic-field-submission .timeline .milestone.final textarea,
+.bz-magic-field-assignment .timeline .milestone.final input,
+.bz-magic-field-submission .timeline .milestone.final input {
+	border: 2px solid #EB3B46;
+}
+
+.bz-magic-field-assignment .timeline input,
+.bz-magic-field-submission .timeline input {
+	width: calc(100% - 20px);
+}
+
+/* Drag and drop: */
+
+[draggable] {
+	cursor: move;
+	padding: 12px!important;
+	position: relative;
+	padding-left: 34px!important;
+	border-left:4px solid white;
+	overflow:hidden;
+}
+[draggable]:before {
+	content: '.. .. ..';
+	position: absolute;
+	left: 12px;
+	top: 50%;
+	line-height: 5px;
+	margin-top: -15px;
+	color: #CCCCCC;
+	font-size: 20px;
+	width:15px;
+}
+.droppable {
+	border-radius: 5px;
+	font-size: 15px;
+	font-family: arial;
+	background: #f3f3f3;
+}
+.droppable div {
+	background: white;
+	box-shadow: 0 2px 2px #d6d6d6;
+	margin:15px;
+}
+#wiki_page_show table.sort-to-match td.droppable{
+	padding: 0!important;
+	position:relative;
+}
+table.sort-to-match tr {
+	overflow: auto;
+	clear: both;
+	box-sizing: border-box;
+	border-top: 1px solid white;
+	padding: 10px;
+	background: #f3f3f3;
+	border-bottom:1px solid white;
+}
+#wiki_page_show table.sort-to-match td, #wiki_page_show table.sort-to-match th {
+	border: none;
+	padding: 0.3em 0.5em !important;
+	box-sizing: border-box;
+	border:none;
+	margin: 20px;
+}
+.droppable.inside-dragging div {
+	background: rgba(224,224,224,.5);
+	box-shadow: 0 2px 2px #d6d6d6 inset;
+}
+
+.sort-to-match.show-answers:not(.bz-locked-table) .incorrect td.droppable:after,
+.sort-to-match.show-answers:not(.bz-locked-table) .correct td.droppable:after{
+	position: absolute;
+    z-index: 1;
+    left: -3px;
+    top: 50%;
+    line-height: 5px;
+    margin-top: -7px;
+    font-size: 15px;
+}
+ .sort-to-match.show-answers:not(.bz-locked-table) .correct td.droppable:after {
+    content: "\2714";
+    color: #22B573;
+}
+.sort-to-match.show-answers:not(.bz-locked-table) .incorrect td.droppable:after {
+    content: "\2717";
+    color: #EB3B46;
+}
+
+.sort-to-match.show-answers:not(.bz-locked-table) .correct .droppable div {
+	border-left:4px solid #22B573;
+}
+
+.sort-to-match.show-answers:not(.bz-locked-table) .incorrect .droppable div {
+	border-left:4px solid #EB3B46;
+}
+
+.sort-to-match.show-answers:not(.bz-locked-table) .correct h6,
+.sort-to-match.show-answers:not(.bz-locked-table) .incorrect h6 {
+ 	color: #FFF;
+}
+
+.bz-locked-table {
+	color: #666;
+}
+
+/* Rubrics and assignment review: */
+.bz-retained-field-replaced {
+	background: #FF0;
+}
+
+.bz-ajax-loaded-rubric {
+	background: #EBF7F7;
+}
+
+#wiki_page_show table.bz-ajax-loaded-rubric .criterion > td,
+.bz-ajax-loaded-rubric .criterion > td {
+	border: 0;
+	padding: 0!important;
+}
+
+.bz-ajax-loaded-rubric .learning_outcome_flag,
+.bz-ajax-loaded-rubric .links,
+.bz-ajax-loaded-rubric .points_form,
+.bz-ajax-loaded-rubric .editing,
+.bz-ajax-loaded-rubric .long_description_holder,
+.bz-ajax-loaded-rubric .threshold {
+	display: none;
+}
+
+.bz-ajax-loaded-rubric .container {
+	margin: 0;
+	width: 100%;
+}
+
+.bz-ajax-loaded-rubric td.rating,
+#wiki_page_show .bz-ajax-loaded-rubric table td.rating {
+	position: relative;
+	padding: 10px !important;
+	padding-bottom: 2.5em !important;
+	border-left: 1px #DDD solid;
+	font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
+	font-size: 13px;
+	vertical-align: top;
+}
+
+#content table.bz-ajax-loaded-rubric td.criterion_description {
+	vertical-align: middle;
+	width: 22%;
+}
+
+.bz-ajax-loaded-rubric .nobr {
+	position: absolute;
+	font-size: 1em;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	text-align: center;
+	border-top: 1px solid #eee;
+	padding: 5px 0;
+}
+
+.bz-clickable-rubric .rating {
+	cursor: pointer;
+}
+
+.bz-ajax-loaded-rubric tr:hover {
+	background: #F6EFDF;
+}
+
+.bz-ajax-loaded-rubric .rating:hover {
+	background: #EDDCBE;
+}
+
+/* Clickable inline rubrics created using magic fields */
+.bz-ajax-loaded-rubric.bz-clickable-rubric td.rating.selected {
+  background: #9AD7D7;
+}
+
+.bz-ajax-loaded-rubric.bz-clickable-rubric:hover td.rating.selected {
+  background: #D1AB5C;
+}
+
+/* Tweak rubric display when presented inside a module so it doesn't overflow */
+.bz-module .bz-ajax-loaded-rubric {
+	font-size: 0.85em;
+}
+
+.bz-module .bz-ajax-loaded-rubric .ratings {
+	table-layout: fixed;
+	width: 100%;
+}
+
+/* Hide the canvas display of rubrics below assignments since we're loading them dynamically into the content: */
+.student-logged-in.assignments #rubrics {
+	display: none;
+}
+
+/* Fine tune how self-evaluation rubrics appear: */
+.bz-rubric-self-eval .criterion_description {
+  width: 30%;
+}
+
+.bz-rubric-self-eval.bz-ajax-loaded-rubric .rating:hover {
+  background: inherit;
+}
+
+.bz-rubric-self-eval .criterion_description_value {
+  font-size: 0.9em;
+}
+
+/* Cube animation */
+.cube-anim {
+  text-align: center;
+  display: inline-block;
+  margin-top: 50px;
+  width: 350px;
+  height: 350px;
+  perspective: 1400px;
+}
+
+.cube-anim .cube {
+  position: relative;
+  width: inherit;
+  height: inherit;
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+}
+
+.cube-anim .cube-face {
+  width: inherit;
+  height: inherit;
+  padding: 10px;
+  position: absolute;
+  background: red;
+}
+
+.cube-anim .cube-face-front {
+  background: #FBFBFB;
+  transform: translate3d(0, 0, 175px);
+}
+
+.cube-anim .cube-face-back {
+  background: #FBFBFB;
+  transform: rotateY(180deg) translate3d(0, 0, 175px);
+}
+
+.cube-anim .cube-face-left {
+  background: #FBFBFB;
+  transform: rotateY(-90deg) translate3d(0, 0, 175px);
+}
+
+.cube-anim .cube-face-right {
+  background: #FBFBFB;
+  transform: rotateY(90deg) translate3d(0, 0, 175px);
+}
+
+.cube-anim .cube-face-top {
+  background: #FBFBFB;
+  transform: rotateX(90deg) translate3d(0, 0, 175px);
+}
+
+.cube-anim .cube-face-bottom {
+  background: #FBFBFB;
+  transform: rotateX(-90deg) translate3d(0, 0, 175px);
+}
+
+#cube-anim-back:checked ~ .cube-anim .cube {
+  transform: rotateY(180deg);
+}
+
+#cube-anim-left:checked ~ .cube-anim .cube {
+  transform: rotateY(90deg);
+}
+
+#cube-anim-right:checked ~ .cube-anim .cube {
+  transform: rotateY(-90deg);
+}
+
+#cube-anim-top:checked ~ .cube-anim .cube {
+  transform: rotateX(-90deg);
+}
+
+#cube-anim-bottom:checked ~ .cube-anim .cube {
+  transform: rotateX(90deg);
+}
+
+@media screen and (max-width: 700px) {
+ .bz-module {
+		width: 100%;
+		padding: 5px;
+	}
+	.module-block.video iframe {
+		width: 100%;
+	}
+	.to-columns {
+		-webkit-column-count: 1;
+		-moz-column-count: 1;
+		-ms-column-count: 1;
+		column-count: 1;
+	}
+}
+
+.bz-in-iframe #bz-module-sequence-progress-container,
+.bz-in-iframe #breadcrumbs,
+.bz-in-iframe .header-bar-outer-container,
+.bz-in-iframe .module-sequence-footer,
+.bz-in-iframe #footer,
+.bz-in-iframe #right-side-wrapper,
+.bz-in-iframe #left-side,
+.bz-in-iframe #bz-help-button,
+.bz-in-iframe #header {
+  display: none;
+}
+
+.bz-in-iframe #main {
+  margin-left: 0px;
+}
+
+
+
+/* Resume module stuff { */
+
+#compare-and-rank {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+}
+
+#compare-and-rank section {
+	display: table-row;
+}
+
+#compare-and-rank .selection-column {
+	display: table-cell;
+	text-align: center;
+}
+
+#compare-and-rank .small {
+	color: #333;
+	display: inline-block;
+	font-family: "Glyphicons Halflings";
+	font-weight: normal;
+	line-height: 1;
+	font-size: 8em;
+	box-sizing: border-box;
+	cursor: pointer;
+}
+#compare-and-rank .small::before {
+	content: "\e022";
+}
+
+#compare-and-rank .view-button {
+	cursor: pointer;
+	margin: 0.5em 0 0.8em 0;
+	color: white;
+	background-color: #5bc0de;
+	border: solid 1px #46b8da;
+	display: inline-block;
+	font-weight: normal;
+	text-align: center;
+	vertical-align: middle;
+	white-space: nowrap;
+	padding: 6px 12px;
+	line-height: 1.4;
+	border-radius: 4px;
+	box-sizing: border-box;
+}
+
+.text-center {
+	text-align: center;
+}
+
+.text-right {
+	text-align: right;
+}
+
+.resume-left {
+	float: left;
+	clear: both;
+}
+
+.resume-right {
+	float: right;
+	text-align: right;
+}
+
+.resume-right + * {
+	clear: both;
+	margin-bottom: 1.5em;
+	display: block;
+}
+
+#resume-comparison-section .html-document,
+#resume-comparison-section .partial-html-document {
+	font-size: 13px;
+}
+
+.context-notes {
+	padding: 3px;
+	position: relative;
+}
+
+.context-notes::before {
+      content: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QMXEDoHPEmf2wAAASBJREFUOMulkyFOxGAQhb92qwYMghAEAoLFAOEAFPScYAW/4ADsrkZhSDccADIQblBLYC9AQHEAdgkGsfJ3BAR/SdO0TQPPvvdmJjPzIgJc7jEVXO5XgCFwCGwEegZMgMxUZoUWIKqYM2BAOy5N5bjwRCXzXejaBY+msudy/zvBOTCqEW4Bc+AFWKpw16biIpf7ZeCjxvxsKjuhwS3Qr9FsJsBJw5jbLvejULzfoBkmwH4D+QWchkV/Ar0aTRoD6w0F3k1l0VQWgIcGzVrcsukyl7SJXvk73uKW8bpgEgPZPwqM2x5pHs7XA87CU5VxYypH5Ve+B9KOnZ9MZdflnjiYMZUD4KKD+aowm8pPFiqJXA1xTkOcI2Aa4jw2lWk5zt+5FmkPTn8zDgAAAABJRU5ErkJggg==");
+      padding: 1px;
+      margin-right: 3px;
+}
+
+.context-notes:hover {
+	background-color: #eee;
+}
+
+.context-notes::after {
+	content: attr(data-content);
+	position: absolute;
+	bottom: 2em;
+	left: 0px;
+	border: solid 1px #ccc;
+	border-radius: 4px;
+	padding: 0.5em;
+	box-shadow: 0px 0px 2px #999;
+	background-color: white;
+	width: 1px;
+	max-height: 1px;
+
+	opacity: 0;
+	transition: opacity 0.25s, width 1.5s, max-height .25s;
+	overflow: hidden;
+}
+
+.context-notes:hover::after {
+	opacity: 1;
+	width: 25em;
+	max-height: 25em;
+	transition: opacity 0.5s;
+}
+
+.html-document {
+	border: solid 1px #000;
+}
+
+.partial-html-document {
+	border-left: solid 1px #000;
+	border-right: solid 1px #000;
+	border-top: dashed 1px #ccc;
+	border-bottom: dashed 1px #ccc;
+}
+
+.modal {
+	position: fixed;
+	left: 0px;
+	right: 0px;
+	top: 0px;
+	bottom: 0px;
+	background-color: black;
+	background-color: rgba(0, 0, 0, 0.8);
+	z-index: 1000;
+}
+
+.modal .modal-content {
+	background-color: white;
+	position: fixed;
+	left: 10%;
+	right: 10%;
+	top: 10%;
+	bottom: 10%;
+	overflow: auto;
+	padding: 1em;
+}
+
+.modal .modal-body {
+	margin: 0.5em;
+}
+
+/* } end resume module stuff */
+
+/* for keyboard drag and drop */
+[aria-grabbed="true"] {
+	box-shadow: 0px 0px 2px 2px black;
+}
+
+
+.my-cohort-info-page {
+  width: 672px;
+  margin: 1em auto;
+}
+
+.my-cohort-info-page table {
+  width: 100%;
+}
+
+.my-cohort-info-page th {
+  width: 25%;
+  text-align: left;
+}
+
+.my-cohort-info-page caption {
+  text-align: left;
+  margin: 2em 0 1em;
+  font-family: "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+  text-transform: uppercase;
+  line-height: normal;
+  font-weight: normal;
+  font-size: 1.2em;
+  color: #EB3B46;
+}
+
+.my-cohort-info-page h1 {
+  font-size: 2em;
+}
+
+.slider-container > span {
+	display: none;
+}
+
+.slider-container.likert-style {
+	display: table;
+	width: 100%;
+	border-spacing: 6px;
+}
+
+.slider-container.likert-style > * {
+	display: table-cell;
+	width: 50%;
+	vertical-align: middle;
+}
+
+.slider-container.likert-style > span {
+	width: 25%;
+}
+
+.slider-container.likert-style > span:first-child {
+	text-align: right;
+}
+
+.slider-container.likert-style > span:last-child {
+	text-align: left;
+}
+
+.slider-container.likert-style input[type=range] {
+	margin: auto;
+	width: 100%;
+}
+
+.bz-explain-grade-link {
+  position: absolute;
+  display: block;
+  bottom: 30px;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  z-index: 2
+}
+
+.grade-explained {
+	padding: 0.25em;
+	box-sizing: border-box;
+	white-space: pre-line;
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+	text-transform: uppercase;
+	border-left: 10px #EB3B46 solid;
+}
+
+.grade-explained.correct {
+	border-color: green;
+}
+
+.grade-explained.partial {
+	border-color: gold;
+}
+
+/* Notifications on home page */
+#bz-announcements-list,
+#bz-announcements-list tr {
+  background: #F3888E;
+    border: none;
+    color: #FFF;
+}
+
+#bz-announcements-list .unread {
+  font-weight: bold;
+  background: #EB3B46;
+}
+
+#bz-announcements-list td {
+  border: none;
+  border-bottom: #FFF 1px solid;
+}
+
+#bz-announcements-list .remove a {
+  background: #FFF;
+  border-radius: 20px;
+  color: #EB3B46;
+  height: 18px;
+  line-height: 0.8;
+  text-decoration: none;
+  width: 18px;
+}
+
+#bz-announcements-list .remove a:hover,
+#bz-announcements-list .remove a:active {
+  color: #000;
+  text-decoration: none;
+}
+
+#bz-announcements-list a {
+  color: #FFF;
+  opacity: 1;
+}
+
+#bz-announcements-list a:hover {
+  text-decoration: underline;
+}
+
+.bz-uploaded-file-display[href=""] {
+  display: none;
+}
+
+.stealth-link {
+	text-decoration: inherit !important;
+	color: inherit !important;
+	cursor: inherit !important;
+}
+
+.stealth-link::hover {
+	text-decoration: inherit !important;
+	color: inherit !important;
+	cursor: inherit !important;
+}
+
+/* transfer from old ui { */
+
+
+.lc-module .bz-heading {
+    text-transform: uppercase;
+    font-weight: bold;
+}
+
+.lc-module .bz-special-event span {
+    color: #eb3b46;
+}
+
+.lc-module .bz-course-overview {
+    margin: 15px auto;
+}
+
+.lc-module .bz-course-overview * {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.lc-module .bz-course-overview tr {
+    border-bottom: 1px solid #222;
+}
+
+.lc-module .bz-course-overview td,
+.lc-module .bz-course-overview th {
+    vertical-align: middle !important;
+}
+
+.lc-module .bz-course-overview tr.bcp {
+    background: #e5e5e5;
+}
+
+.lc-module .bz-course-overview tr.dyc {
+    background: #eaf6f6;
+}
+
+.lc-module .bz-course-overview tr.exp {
+    background: #f5eede;
+}
+
+.lc-module .bz-course-overview tr.cap {
+    background: #f8d7d9;
+}
+
+.lc-module .bz-course-overview tr.gen,
+.lc-module .bz-course-overview th {
+    background: #f2f2f2;
+    color: #000;
+}
+
+.bz-toc-current {
+    color: #eb3b46 !important;
+}
+
+#bz-auto-toc {
+	padding: 24px 0px;
+	margin: 24px auto;
+    border: 1px dotted #e6e6e6;
+}
+
+#bz-auto-toc li {
+    border-left: 12px solid #e6e6e6 !important;
+    border-radius: 0 !important;
+    padding: 12px 24px;
+}
+#bz-auto-toc li.bz-toc-current,
+#bz-auto-toc .bz-toc-current-wrapper .ig-row {
+    border-left: 12px solid #eb3b46 !important;
+}
+#bz-auto-toc a {
+   text-decoration: none !important;
+   /*cursor: text !important;*/
+}
+#bz-auto-toc .indent_1,
+#bz-auto-toc .indent_2,
+#bz-auto-toc .indent_3,
+#bz-auto-toc .ig-header,
+#bz-auto-toc .ig-admin,
+#bz-auto-toc .draggable-handle,
+#bz-auto-toc i,
+#bz-auto-toc .context_module_sub_header,
+#bz-auto-toc .requirement-description {
+    display:none;
+}
+#bz-auto-toc li {
+    margin: 0;
+}
+
+#bz-auto-toc ol {
+	list-style-type: none;
+}
+
+#bz-auto-toc li,
+#context_modules .ig-title,
+#context_modules .ig-header-title {
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", "Open Sans", sans-serif;
+	font-size: 1.2em;
+}
+
+/* end transfer from old ui } */
+
+body.pages #content {
+	overflow: visible !important; /* canvas hiding scroll bars doesnt allow sticky progress in module */
+}
+
+.pages.show .show-content {
+	overflow-x: visible !important; /* otherwise canvas breaks our sidebar */
+}
+
+#bz-progress-bar {
+	position: sticky;
+	float: right;
+	right: 1em;
+	top: 1em;
+	width: 260px;
+	z-index: 10;
+}
+
+#bz-progress-bar > div {
+	padding: 0.5em;
+	background-color: #f7f7f7;
+	margin-bottom: 1em;
+}
+
+#bz-progress-bar ol {
+	list-style-type: none;
+	counter-reset: mastery-counter;
+	padding: 0px;
+}
+
+#bz-progress-bar ol li {
+	counter-increment: mastery-counter;
+	position: relative;
+	margin: 0.5em 0px;
+	padding-left: 30px;
+}
+
+#bz-progress-bar ol li::before {
+	content: counter(mastery-counter);
+	display: inline-block;
+	text-align: center;
+	color: #adadad;
+	font-weight: bold;
+	font-size: 16px;
+	width: 24px;
+	height: 24px;
+	line-height: 24px;
+	vertical-align: middle;
+
+	position: absolute;
+	left: 0px;
+	top: 0px;
+}
+
+#bz-progress-bar progress {
+	height: 1em;
+	width: 100%;
+
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	border: none;
+}
+
+#bz-progress-bar progress::-webkit-progress-bar {
+	background-color: #e2e2e2;
+	color: #e2e2e2;
+}
+
+/* important note: the prefixed versions for -webkit- and -moz- MUST appear as separate statements or chrome will ignore it! */
+#bz-progress-bar progress::-webkit-progress-value,
+#bz-progress-bar progress::-webkit-progress-bar-value {
+	background: #eb3b46;
+}
+
+#bz-progress-bar progress::-moz-progress-bar {
+	background: #eb3b46;
+}
+
+#bz-progress-bar progress {
+	color: #eb3b46;
+}
+
+#bz-progress-bar .correct-mastery-item,
+#bz-progress-bar .incorrect-mastery-item,
+#bz-progress-bar .unanswered-mastery-item {
+	display: inline-block;
+	width: 24px;
+	height: 24px;
+	border-radius: 12px;
+	font-size: 0px;
+	vertical-align: top;
+	margin-right: 4px;
+	margin-bottom: 4px;
+}
+
+#bz-progress-bar .correct-mastery-item {
+	background-color: #10c46e;
+	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4wgHAxcCGGjrFwAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAACPElEQVRIx61WQWjTUBj+mm6B2i6Ybgw3mmwOCgXFHaKe7M2DUArKEJmelF3qSVDobWNeZBfpQfQyPQh2lw0Gc5fpvKxDUCMULMKKcybbimNtbWl4EjfmoaY2tHvJ032n5OXl//7v/9///89DCDkABRu/SlitfsGmWcZKNd9YjwphhHgRMfE0jnO+Q//3HEagGhqmdzKYL2XhhMvBYSRDlzDYGXRHMFVYQmp7GSwQvD6MSzHc6D5HJ0h8TbvymqbmycnrjXfuKI0DwHwpi6nCUivBYjX338YtpLaXoRqanWDy2wKzISUgQwnIbb9NbC78JXhRfA/dLDMl9O2ZJF4P34XEixC8rcdUrWlQDQ0dAJBpOt9u8HDoKiJd/bj5+Rk1rNM7mbqCN5U118YlXsRIr4KnWyuOOdPNcp2guk9cE0wMxFHZI7ivLzruVWsaOCvbtERKvGjzPqW/cu1Uh1MyHw2Nos8nYiT3GFEhDACY2/3oWrGHEHLQpyapCuZO3QYxf+LHPkGOFDCWf+6agLOk0+J4Jz+DE8dERLr68bKYZaoTznpwKv/V4hoqe4Sp2qNCuE4w1nvBcXNiPY3Z7x+Y6uVaz9k/CvyyowrdLOPexixTVx3sDDb1olC8bcn/CwSvDw8GrtibneKXMS7FjoQgHb7VGKO2OrCmEUso2k01xS/TR6ZqaEisp5k6rBKQMRmK24xTh77Vxmd230GtaVTDoz3nW2axK4Lmq0uOFPDJ2GqsXRQi6OYDbW8SzfgNmcfld30i4sAAAAAASUVORK5CYII=);
+}
+
+#bz-progress-bar .incorrect-mastery-item {
+	background-color: #eb3b46;
+	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4wgHAxY1uc5/WQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAChklEQVRIx62VMWgTYRTHf3eXXNP0mkWIAVFoEjcl0inUiENpoB0EO9RNoXRoBytIK1IFKVgFU8HqpJMIHXRoSwm0FNxC7SQUOmnS4NbGQUwuTZvL3TmkSRqby0Xb/3b38b3f+977f+8TCoWCSQOZZvm3lviCkUpT2tyqrsnnfEgXzkP3FcRAF4IgYCWhEcBU82gLy5SW4hjZHM0kBf3IYyNIoUutAfTNLYqxV+g7Gf5FzkgYeeIegtJhDSitfWb/xRz/KynoxzU7UwcRj2Z+kuAAenKb/YlHmGq+HmCqeQ6mn3Ma0pPb6O/n6wHawrJtM/+W3B1C7g41XNtfimPulnsommqe0lLctrZnVheQgn4AXAN9eF7HcBx+NzzJ/McyQF/fsM3ezPxEUBTctwZxRsIoU5McrKyx92nRck8xsQGAg28pEADTGmBkc2iJddr6o8jXetCTKXIzs02TMrI5jFQaUUv/aBq8or34atnXikL24ZOW+mTs7NZsaifX9UjtQ1FaA6TSrQHcQzdp64+iJ1Pl+CO37TcJ4HS32wOkoB/3+BjGbobf4w/QEus4Iz2WFq05A4yLQUSrIVWR5/EkAOpMDCObI/fsJaaqordwb0SfF4cY6LKu+0AfUjDAwcoaxa+bVXf8GrpjP2V9XoSzXkTH1TCSz2vhggymqpJ/8/aYBW1LG+2tTdOTTtFjpfF00v7hHYLSUW6yI9qLFLp8agB5dLg6sqsuck1PIXo6TxzcNdCH47A8dQBB6cAVe2rZj5aD37/b/Mk01TzF2Tm0w2HVas3l0eG6zJs++pUXrrS43BQk+bxI0V6cgzeOvcW2gKMnMlJpxO9JtL1C9QKJAT/N7lBFfwCDtAlhOytPuAAAAABJRU5ErkJggg==);
+}
+
+#bz-progress-bar .unanswered-mastery-item {
+	background-color: #e6e6e6;
+}
+
+/* Quick Quiz */
+/* ---------- */
+.bz-quick-quiz-container {
+	width: 100%;
+	position: relative;
+	padding: 5px 40px;
+	background: #e1e1e1;
+	left: -40px;
+	bottom: -15px;
+}
+.bz-quick-quiz {
+	background: #fff;
+	margin: 40px auto;
+	width: 67%;
+	padding: 20px;
+	border: 1px solid #ccc;
+}
+
+.bz-quick-quiz li {
+	min-height: 30px;
+	padding: 5px 5px 5px 35px;
+	border-bottom: 1px solid #ccc;
+	position: relative;
+}
+
+.bz-quick-quiz li:first-child {
+	border-top: 1px solid #ccc;
+}
+
+.bz-quick-quiz .success {
+	color: green;
+}
+
+.bz-quick-quiz .fail {
+	color: red;
+}
+
+.bz-quick-quiz .success:before,
+.bz-quick-quiz .fail:before {
+	display: table-cell;
+	vertical-align: middle;
+	font: bold 16px;
+	position: absolute;
+	left: 0;
+	height: 30px;
+	width: 30px;
+	text-align: center;
+}
+
+.bz-quick-quiz .success:before {
+	content: "\2713 ";
+}
+
+.bz-quick-quiz .fail:before {
+	content: "\2718 ";
+}
+
+/* CSS for Application Ritual: */
+/* -------------------- */
+
+.bz-app-ritual input,
+.bz-app-ritual label {
+	display: block;
+}
+
+.bz-app-ritual input.bz-app-ritual-check,
+.bz-app-ritual input.bz-app-ritual-my-semester,
+.bz-app-ritual input.bz-app-ritual-my-semester[type='number']{
+	border: none;
+	display: inline-block;
+	padding: 0 0 0 0;
+	background:transparent;
+	box-shadow: none;
+	-webkit-appearance: none;
+	font-family: inherit;
+	font-size: inherit;
+	color: inherit;
+	cursor: text;
+}
+
+.bz-app-ritual input.bz-app-ritual-check.bz-app-ritual-check-validated{
+	width: 24px;
+	height: 24px;
+	color: white;
+	background: #30b56c;
+	text-align: center;
+	border-radius: 12px;
+	text-shadow: 1px 2px #1e905a;
+	font-family: inherit;
+	font-size: 14px;
+}
+
+.bz-app-ritual input.bz-app-ritual-check.bz-app-ritual-check-unmet{
+	background: #EB3B46;
+	text-shadow: 1px 2px #af1119;
+}
+
+.bz-app-ritual input.bz-app-ritual-check{
+	background: transparent;
+	text-shadow: none;
+}
+
+#bz-app-ritual-opportunity-2,
+.bz-app-ritual .modal,
+.bz-app-ritual-body #bz-progress-bar .bz-graded-question,
+.bz-app-ritual-body #bz-progress-bar div progress{
+	display: none;
+}
+
+.bz-app-ritual .criteria-desc {
+	float: left;
+	width: 50%;
+	margin-right:10%;
+}
+
+.bz-app-ritual .criteria-slider {
+	float: right;
+	width: 40%;
+	position: relative;
+}
+
+.bz-app-ritual .criteria-slider input.slider{
+	width: 100%;
+}
+
+.modal-content .container{
+	max-width: 100%;
+}
+
+.bz-app-ritual-body #bz-progress-bar{
+	width: 100%;
+	top: 0;
+	background-color: #FFFFFF;
+	border-bottom: 1px solid #eee;
+	margin-bottom: 1em;
+	margin-top: -30px;
+}
+
+.bz-app-ritual-body #bz-progress-bar>div{
+	margin-bottom: 1em;
+	text-align: center;
+	background-color: white;
+	padding-bottom: 0;
+	padding: 1em 0 0 0;
+	font-size: 14px;
+}
+
+#wiki_page_show .bz-app-ritual table tr.bz-app-ritual-module td:last-child,
+#wiki_page_show .bz-app-ritual table tr.bz-app-ritual-module-head th:last-child{
+	background: transparent;
+	border-color: transparent;
+}
+
+table.bz-app-ritual-applications,
+form.bz-app-ritual-opportunity,
+.bz-app-ritual-modal{
+	font-weight: normal;
+	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+	font-size: 16px;
+}
+
+table.bz-app-ritual-applications,
+form.bz-app-ritual-opportunity{
+	margin: 30px 0 40px 0;
+}
+
+table.bz-app-ritual-applications th{
+	font-family: inherit;
+	font-size: inherit;
+	text-transform: inherit;
+}
+
+table.bz-app-ritual-applications th strong{
+	text-transform: uppercase;
+}
+
+input.bz-app-ritual-my-week-value,
+input.bz-app-ritual-my-semester{
+	width:35%;
+	margin-bottom:0;
+}
+
+#wiki_page_show .bz-app-ritual table td, 
+#wiki_page_show .bz-app-ritual table th{
+	border:none;
+}
+
+#wiki_page_show .bz-app-ritual table tr td{
+	background-color: rgba(226,226,226, 0.3);
+	border-bottom: 1px solid #e8e6e6;
+}
+
+.bz-app-ritual-applications .what{
+	font-weight:bold;
+}
+
+.bz-app-ritual-applications .when {
+	display: block;
+	font-weight: normal;
+	text-transform: uppercase;
+	font-size: 80%;
+	margin-top:5px;
+}
+
+.bz-app-ritual-applications .what, 
+.bz-app-ritual-applications .when {
+	white-space: nowrap;
+}
+
+.bz-app-ritual input.bz-app-ritual-my-semester,
+.bz-app-ritual-goal,
+.bz-app-ritual input.bz-app-ritual-my-semester[type='number']{
+	font-style: italic;
+	color: #999999;
+}
+
+table.bz-app-ritual-applications th{
+	text-align:left;
+}
+
+#wiki_page_show .bz-app-ritual table tr.bz-app-ritual-module td:nth-child(2),
+#wiki_page_show .bz-app-ritual table tr.bz-app-ritual-module-head th:nth-child(2){
+	background: rgba(226, 226, 226, 0.63);
+}
+
+#wiki_page_show .bz-app-ritual table tr.bz-app-ritual-module td:nth-child(2){
+	border-bottom: 1px solid #e0dfdf;
+}
+
+table.bz-app-ritual-applications input[type='number'],
+.bz-app-ritual.bz-module .bz-app-ritual-opportunity input{
+	background-color: #FFFFFF;
+	font-family: inherit;
+	font-size: inherit;
+}
+
+table.bz-app-ritual-applications td.bz-app-ritual-module-name{
+	white-space: nowrap;
+}
+
+form.bz-app-ritual-opportunity{
+	padding:20px;
+	background-color: rgba(226,226,226, 0.3);
+	border: 1px solid #e8e6e6;
+}
+
+.bz-app-ritual button{
+	border: none;
+	background: #EB3B46;
+	color: #FFF;
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+	text-transform: uppercase;
+	line-height: normal;
+	font-weight: normal;
+	font-size: 1.2em;
+}
+
+form.bz-app-ritual-opportunity a.bz-app-ritual-calculate-link {
+	padding: 10px;
+	display: block;
+	text-transform: uppercase;
+}
+
+.bz-app-ritual-opportunity small {
+	color: #777777;
+	font-size: inherit;
+}
+
+.bz-app-ritual-opportunity section{
+	overflow: auto;
+}
+
+.bz-app-ritual.bz-module input[name='score']{
+	width: 50px;
+	float: left;
+	min-width: auto;
+	margin-right: 10px;
+}
+
+.bz-app-ritual-modal h6{
+	color: #000000;
+}
+
+.bz-app-ritual-modal section.sense-check-container h6{
+	color: #378383;
+}
+
+.bz-app-ritual-modal section:not(.fixed-position-container) section{
+	padding: 20px;
+	box-sizing: border-box;
+	background: rgba(226,226,226, 0.3);
+	margin-bottom: 5px;
+	overflow: auto;
+}
+
+.bz-app-ritual-modal section.sense-check-container section{
+	background: #D7EFEF;
+}
+
+.bz-app-ritual-modal section.fixed-position-container section{
+	float: right;
+}
+
+.bz-app-ritual-modal .fixed-position-container{
+	background: white;
+	position: fixed;
+	left: 10%;
+	right: 10%;
+	bottom: 10%;
+	width: auto;
+	padding: 1em;
+	border-top: 1px solid #eeeeee;
+	box-shadow: 0 -4px 10px #3333331a;
+}
+
+.bz-app-ritual-modal .fixed-position-container span{
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+	font-size: 1.2em;
+	margin-right: 10px;
+}
+
+.bz-app-ritual-modal .fixed-position-container button{
+	font-size: 1.4em;
+}
+
+.bz-app-ritual-modal .sense-check-container {
+	margin-bottom: 80px;
+}
+
+.bz-app-ritual-modal .close{
+	position: fixed;
+	top: 12%;
+	right: 11%;
+	background: white;
+	height: 28px;
+	width: 28px;
+	border-radius: 14px;
+	text-align: center;
+	line-height: 22px;
+	border: 1px solid #eeeeee;
+	box-shadow: 0 0 10px #3333331a;
+	z-index: 1;
+	opacity: 1;
+	font-size: 22px;
+}
+
+.bz-app-ritual-modal .bz-app-ritual-score-text:after{
+	content: "/60";
+}
+
+.bz-app-ritual-modal .bz-app-ritual-score-text{
+	color: #EB3B46;
+}
+
+.bz-app-ritual-modal .fixed-position-container p{
+	display: inline;
+	margin-bottom: 0;
+}
+
+.bz-app-ritual-modal .fixed-position-container section>span{
+	float: left;
+}
+
+.bz-app-ritual-opportunity .bz-app-ritual-confirm p:first-child{
+	text-transform: uppercase;
+	color: #30b56c;
+	font-family: "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+	font-size: 1.3em;
+	margin-top: 10px;
+	margin-bottom: 0;
+}
+
+
+/* New CSS */
+.module-checkbox-div {
+    padding-left: 2em;
+    position: relative;
+    /* vertical-align: middle; */
+    margin: 0.5em 0;
+}
+
+input.module-checkbox-div {
+    position: absolute;
+    left: 0;
+}
+
+.module-checkbox-div input {
+    position: absolute;
+    left: 0;
+}
+
+.question {
+    background-image: url('images/lms-icons-04.png');
+    /* background-repeat: no-repeat; */
+    /* background: 0px 50px no-repeat; */
+}
+
+.module-block > div {
+    padding: 60px;
+    padding-right: 0;
+    border-top: 1px solid #CCC;
+    border-bottom: 1px solid #CCC;
+    margin-bottom: -1px;
+}
+
+.module-block.module-block-quote > div {
+    background: bottom center no-repeat #D1AB5C;
+    background-image: url(images/bkg700-01.jpg);
+    position: relative;
+    margin: 3em 0;
+    width: calc( 100% - 6em );
+    padding: 3em;
+    font-style: italic;
+    font-size: 1.2em;
+    text-align: center;
+    color: #FFF;
+}
+
+blockquote small {
+    display: block;
+    line-height: 20px;
+    margin: 1em 0;
+    font-size: 75%;
+}
+
+blockquote {
+    margin: 0 0 20px;
+}
+
+.bz-module .answer.correct h5 {
+	color: #22B573;
+}
+
+.bz-module .answer.incorrect h5 {
+	color: #C1272D;
+}
+.bz-module input {
+    margin-top: 4px
+}
+
+.bz-module input[data-correctness="correct"] + label {
+    color: green;
+}
+
+.bz-module input[data-correctness="incorrect"] + label {
+    color: red;
+}
+
+.bz-module input[data-correctness="maybe"] + label,
+.bz-module input[data-correctness=""] + label {
+    color: #a54c2a;
+}


### PR DESCRIPTION
This adds an initial version of the `braven_newui.css` file used for `BRAVEN_NEW_HTML` pages, as enabled by https://github.com/beyond-z/canvas-lms/pull/569 and https://github.com/bebraven/platform/pull/113.

This is mostly a copy of bz_newui.css, with the relevant bz-box styles renamed to module-block. Ad the bottom of the file is some extra CSS for other HTML structural changes we've made.