### PR TITLE
Update answer title selector to fix verbose feedback JS

### DIFF
--- a/braven_custom.js
+++ b/braven_custom.js
@@ -299,7 +299,7 @@ jQuery( document ).ready(function() {
 
 // Show feedback in an answer following a question:
 function bzGiveVerboseFeedback(feedback, answerSpace, feedbackClass) {
-  jQuery(answerSpace).addClass(feedbackClass).find('.box-title').text(feedback);
+  jQuery(answerSpace).addClass(feedbackClass).find('h5').text(feedback);
 }
 
 /*


### PR DESCRIPTION
Summary: We didn't update the selector for this Module-JS for the post-conversion HTML, so the code that sets e.g. checkbox answers to "You got 2 out of 3 correct!" doesn't work.

Task: https://app.asana.com/0/1142638035116665/1166953651889443/f

We no longer use `class="box-title"` on answer titles. They're all `h5`s now.