### PR TITLE
Fix block quote left margin

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -1124,6 +1124,10 @@ input[type='button'].add-other-field {
 }
 */
 
+.module-block.module-block-quote > div.content {
+	padding-left: 0px;
+}
+
 .module-block[data-icon="module-block-video"] > div.content h5,
 .module-block[data-icon="module-block-video"] > div.question h5,
 .module-block > div.answer,


### PR DESCRIPTION
**Task**: Icon changing. This fixes the issue with blockquotes caused by https://github.com/beyond-z/canvas-lms-js-css/pull/296. 

**Test**
- Test against *stagingplatform*
- Go to https://stagingplatform.bebraven.org/course_contents/1/edit, paste in CSS in Chrome console:
<img width="1453" alt="Screen Shot 2020-05-07 at 11 09 53 AM" src="https://user-images.githubusercontent.com/62911934/81330355-d39a9f80-9054-11ea-92f9-fd84bfdef849.png">

**Details**
- This fixes stagingplatform as it is now, e.g. before the class name changes in https://github.com/bebraven/platform/pull/195


