### PR TITLE
Override CSS for blockquotes inside body

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -286,6 +286,16 @@ blockquote .bz-hashtag {
 	content:"\2014 \00a0";
 }
 
+div.module-block:not(.block-quote-bg) blockquote {
+        padding: 0 1.5em;
+        margin: 0;
+        border-left: none;
+        width: 100%;
+        background: none;
+        color: black;
+        font-size: 18px;
+}
+
 .bz-module > div[data-replaced-with-page] > p:not(.match-heading-style),
 .bz-module > p:not(.match-heading-style) {
 	margin: 3em 0;


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1168290061278554/f

This is meant to override block-quote-bg CSS, which is applied too broadly.

Example before/after

<img width="1246" alt="Screen Shot 2020-05-11 at 1 34 10 PM" src="https://user-images.githubusercontent.com/1382374/81598085-5fca0100-938c-11ea-85ec-dce4d758aec0.png">
<img width="703" alt="Screen Shot 2020-05-11 at 1 35 50 PM" src="https://user-images.githubusercontent.com/1382374/81598092-622c5b00-938c-11ea-8502-763a92537cac.png">
