### PR TITLE
Hide mastery sidebar

### DIFF
--- a/braven_custom.js
+++ b/braven_custom.js
@@ -1287,7 +1287,7 @@ function createBzProgressBar() {
         if(e.matches(".done-button"))
           boxPosition++;
 
-        if(!e.matches("[data-bz-answer]"))
+        if(!e.matches("[data-bz-answer]") || !e.closest('[data-mastery="true"]'))
           continue;
 
         var box = e;


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1172766526299178/f

Summary: Hide the mastery sidebar when there are no questions matching `[data-mastery="true"]`. 

As part of investigating this issue, I realized mastery questions are broken globally in converted modules, due to my misunderstanding of how the JS and old HTML represented and detected them. This PR does *not* address that. It will hide the mastery sidebar everywhere. We'll have to fix mastery questions later, since it's out of scope for booster.

Screenshot: (showing a lack of mastery sidebar)
<img width="280" alt="Screen Shot 2020-05-12 at 12 46 08 PM" src="https://user-images.githubusercontent.com/1382374/81727460-9ec08b00-944e-11ea-84dc-e9ce1196690b.png">

