### PR TITLE
Style slider for new content editor HTML

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2642,6 +2642,11 @@ table.sort-to-match tr {
 	width: 100%;
 }
 
+.module-block > div.question input[type=range] {
+	margin: auto;
+	width: 100%;
+}
+
 .bz-explain-grade-link {
   position: absolute;
   display: block;

--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2643,8 +2643,10 @@ table.sort-to-match tr {
 }
 
 .module-block > div.question input[type=range] {
-	margin: auto;
-	width: 100%;
+	width: 66%;
+	height: auto;
+	margin: 2em 17%;
+	text-align: center;
 }
 
 .bz-explain-grade-link {


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1174547828723905

**Test**

- Create empty sections, add slider question, rate this module, and a slider in a table
- Here's the code tab input I tested with: https://pastebin.com/DJfd1hPp
- Save and publish to local canvasweb

**Slider question**
- Before CSS change the slider in a question doesn't take up the full width:
<img width="1788" alt="Screen Shot 2020-05-14 at 3 41 40 PM" src="https://user-images.githubusercontent.com/62911934/81992908-6b6e2f80-95f9-11ea-9907-6457cb61b946.png">

- After CSS change, pasted into Chrome console, slider at full width:
<img width="1792" alt="Screen Shot 2020-05-14 at 3 42 05 PM" src="https://user-images.githubusercontent.com/62911934/81992932-7b860f00-95f9-11ea-96bd-070cd83d2b18.png">

**Rate this module**: looks the same as before
<img width="734" alt="Screen Shot 2020-05-14 at 3 37 40 PM" src="https://user-images.githubusercontent.com/62911934/81993916-948fbf80-95fb-11ea-845d-39f2d46f1c0e.png">

**Slider input in table**: looks the same as before
<img width="1785" alt="Screen Shot 2020-05-14 at 3 54 02 PM" src="https://user-images.githubusercontent.com/62911934/81993928-9ce7fa80-95fb-11ea-838e-384672fde22b.png">

**Details**

- The CSS is looking for `<div class="slider-container range">` to apply the slider styling, which we're not generating from the new editor. Instead, we look for a range input within a question and apply the full-width CSS. 