### PR TITLE
Limit shuffling of fieldset children

### DIFF
--- a/braven_custom.js
+++ b/braven_custom.js
@@ -615,8 +615,13 @@ function bzInitializeNewUi() {
   });
   */
 
-  // Mix up checklists:
-  jQuery('fieldset').not('.dont-mix').each(function(){
+  // Mix up radio and checklists unless marked dont-mix
+  jQuery('fieldset').not('.dont-mix').each(function() {
+    var fieldset = jQuery(this);
+    var validChildren = fieldset.children('.module-checkbox-div, .module-radio-div');
+    if (validChildren.length != fieldset.children().length) {
+      return; // there's a non-checkbox or non-radio in the fieldset, don't shuffle
+    }
     shuffleChildren(this);
   });
 


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1175471955522877, https://app.asana.com/0/1170776727341290/1175281876558207

**Test**

- Save and Publish content to local canvasweb
- I had to use a new incognito window every time to test JS changes so the browser wouldn't cache it

**Inputs we don't shuffle:**
- Custom question with email fields from this task: https://app.asana.com/0/1170776727341290/1175471955522877. This has one checkbox input in the fieldset, but a bunch of other types of inputs, so we don't shuffle.
- Checklist question with "other" option. This has a `dont-mix` class set on it. 
- Rate This Module from this task: https://app.asana.com/0/1170776727341290/1175281876558207. This has no checkbox, no radio inputs, don't shuffle. 
- Slider questions: again, no checkbox, no radio inputs, don't shuffle.
<img width="580" alt="Screen Shot 2020-05-15 at 3 22 12 PM" src="https://user-images.githubusercontent.com/62911934/82100917-e13cce80-96bf-11ea-8855-be5d27a2b940.png">

**Inputs we do want to shuffle:**
- Plain old checklist
- Plain old radio
<img width="1180" alt="Screen Shot 2020-05-15 at 3 12 35 PM" src="https://user-images.githubusercontent.com/62911934/82100828-a8045e80-96bf-11ea-9a37-81f5b31c1ac5.png">

**Details**

- I didn't use the `input[type=radio], input[type=checkbox]` selector because the inputs in the fieldset are actually wrapped in `<div>s` to accommodate things like inline feedback, etc., so we are dependent on these specific classnames being in the HTML