### PR TITLE
Clearfix for floats in resume snippets

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2544,13 +2544,24 @@ table.sort-to-match tr {
 	border-bottom: dashed 1px #ccc;
 }
 
-/* This is clearfix: https://css-tricks.com/all-about-floats/#article-header-id-3*/
+/* These are clearfix: https://css-tricks.com/all-about-floats/#article-header-id-3 */
+
+/* Clearfix after every inline resume snippet */
 .partial-html-document:after { 
-   content: "."; 
-   visibility: hidden; 
-   display: block; 
-   height: 0; 
-   clear: both;
+	content: "."; 
+	visibility: hidden; 
+	display: block; 
+	height: 0; 
+	clear: both;
+}
+
+/* Clearfix before each div in the resume snippet */
+.partial-html-document > div:before {
+	content: "."; 
+	visibility: hidden; 
+	display: block; 
+	height: 0; 
+	clear: both;
 }
 
 .modal {

--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2476,7 +2476,6 @@ table.sort-to-match tr {
 
 .resume-left {
 	float: left;
-	clear: both;
 }
 
 .resume-right {
@@ -2485,7 +2484,6 @@ table.sort-to-match tr {
 }
 
 .resume-right + * {
-	clear: both;
 	margin-bottom: 1.5em;
 	display: block;
 }
@@ -2544,6 +2542,15 @@ table.sort-to-match tr {
 	border-right: solid 1px #000;
 	border-top: dashed 1px #ccc;
 	border-bottom: dashed 1px #ccc;
+}
+
+/* This is clearfix: https://css-tricks.com/all-about-floats/#article-header-id-3*/
+.partial-html-document:after { 
+   content: "."; 
+   visibility: hidden; 
+   display: block; 
+   height: 0; 
+   clear: both;
 }
 
 .modal {


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1174953216295177

**Test**

- Copy Booster Module 1 to `platformweb`
- Save and Publish to local `canvasweb`
- Paste in CSS changes to Chrome inspector
- Click "Done" a lot to find resume section

<img width="970" alt="Screen Shot 2020-05-15 at 4 10 26 PM" src="https://user-images.githubusercontent.com/62911934/82103194-01bc5700-96c7-11ea-9b3d-bb83fcf16483.png">
<img width="980" alt="Screen Shot 2020-05-15 at 4 10 54 PM" src="https://user-images.githubusercontent.com/62911934/82103197-03861a80-96c7-11ea-9438-8adcf98b720f.png">


**Details**

- `resume-left` and `resume-right` use floats and try to clear afterwards, but it's not working
- hence parent `<div>` ends up a weird size, hence the dotted border being in the wrong spot and the surrounding text wrapping bizarrely
- I lifted the standard `clearfix` from here: https://css-tricks.com/all-about-floats/#article-header-id-3 and applied it on the resume snippet class so that does the float clearing, rather than the individual resume elements trying to do it themselves