### PR TITLE
Editor resumemodal

### DIFF
--- a/braven_custom.js
+++ b/braven_custom.js
@@ -1964,34 +1964,58 @@ for (var key in ENV) {
 var activeModal = null;
 
 document.body.addEventListener("click", function(event) {
-	var ele = event.target;
-	if(ele.getAttribute("data-toggle") == "modal" && ele.hasAttribute("data-target")) {
-		if(activeModal) {
-			activeModal.style.display = "none";
-			activeModal = null;
-		}
 
-		var thing = document.querySelector(ele.getAttribute("data-target"));
-		if(thing) {
-			thing.style.display = "";
-			activeModal = thing;
-		}
-	} else if(ele.parentElement && ele.parentElement.getAttribute("data-toggle") && ele.parentElement.hasAttribute("data-target")) {
-    if(activeModal) {
+  // Returns true iff the element has the attributes we need to launch a modal
+  function hasModalAttributes(element) {
+    return (element
+      && element.getAttribute("data-toggle") == "modal"
+      && element.hasAttribute("data-target")
+    );
+  }
+
+  // Returns the ID of the modal associated with the element
+  function getTargetModal(element) {
+    if (hasModalAttributes(element)) {
+      return element.getAttribute("data-target");
+    }
+
+    if (hasModalAttributes(element.parentElement)) {
+      return element.parentElement.getAttribute("data-target");
+    }
+
+    return null;
+  }
+
+  // Hides the current modal
+  function deactivateModal() {
+    if (activeModal) {
       activeModal.style.display = "none";
       activeModal = null;
     }
+  }
 
-    var thing = document.querySelector(ele.parentElement.getAttribute("data-target"));
-    if(thing) {
-      thing.style.display = "";
-      activeModal = thing;
+  // Shows the specified modal
+  function displayModal(modalId) {
+    var modal = document.querySelector(modalId);
+    if (!modal) {
+      return;
     }
-  } else if(ele.classList.contains("modal")) {
-		if(activeModal) {
-			activeModal.style.display = "none";
-			activeModal = null;
-		}
-	}
+    modal.style.display = "";
+    activeModal = modal;
+  }
+
+  // Clicked on something that launches a modal
+  var targetModal = getTargetModal(event.target);
+  if (targetModal) {
+    deactivateModal();
+    displayModal(targetModal);
+    return; 
+  }
+
+  // Assume we're clicking out of the modal and hide it
+  if (event.target.classList.contains("modal")) {
+    deactivateModal();
+  }
+
 });
 })();

--- a/braven_custom.js
+++ b/braven_custom.js
@@ -1976,7 +1976,18 @@ document.body.addEventListener("click", function(event) {
 			thing.style.display = "";
 			activeModal = thing;
 		}
-	} else if(ele.classList.contains("modal")) {
+	} else if(ele.parentElement && ele.parentElement.getAttribute("data-toggle") && ele.parentElement.hasAttribute("data-target")) {
+    if(activeModal) {
+      activeModal.style.display = "none";
+      activeModal = null;
+    }
+
+    var thing = document.querySelector(ele.parentElement.getAttribute("data-target"));
+    if(thing) {
+      thing.style.display = "";
+      activeModal = thing;
+    }
+  } else if(ele.classList.contains("modal")) {
 		if(activeModal) {
 			activeModal.style.display = "none";
 			activeModal = null;

--- a/braven_custom.js
+++ b/braven_custom.js
@@ -2011,9 +2011,12 @@ document.body.addEventListener("click", function(event) {
     displayModal(targetModal);
     return; 
   }
+  debugger;
 
-  // Assume we're clicking out of the modal and hide it
+  // Clicked in area outside of the resume snippet itself, 
+  // assume user wants out of the modal and hide it
   if (event.target.classList.contains("modal")) {
+    debugger;
     deactivateModal();
   }
 


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1174957265437154

**Test**
- It's a screencast but GitHub only lets me upload `.zip`: [test.mov.zip](https://github.com/beyond-z/canvas-lms-js-css/files/4637597/test.mov.zip)
- Go to Module 2, find the resumes, click on text and then on button, both open the modal

**Details**

- Commit 1: is the hacky fix to check the parent
- Commit 2: I tried to clean up the code, so it's more readable. There's more code, but hopefully it makes a little more sense. I will take any and all code style recommendations here because there's a global variable that makes me kind of uncomfortable but I don't know how to get rid of it.
