### PR TITLE
Scale blockquote bg image up if the text is too big

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -233,6 +233,7 @@ blockquote {
 .bz-module blockquote {
 	background: bottom center no-repeat #D1AB5C;
 	background-image: url('images/bkg700-03.jpg');
+	background-size: cover;
 	position: relative;
 	margin: 3em 0;
 	width: calc( 100% - 6em );


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1175259849509860/f

screenshot:
<img width="718" alt="Screen Shot 2020-05-18 at 3 58 58 PM" src="https://user-images.githubusercontent.com/1382374/82259007-8229c480-9920-11ea-8487-dfb4b0cd86b0.png">
