### PR TITLE
Apply stealth-link style to all heading links

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2752,17 +2752,28 @@ table.sort-to-match tr {
   display: none;
 }
 
+h2 > a,
+h3 > a,
+h4 > a,
+h5 > a,
+h6 > a,
 .stealth-link {
 	text-decoration: inherit !important;
 	color: inherit !important;
 	cursor: inherit !important;
 }
 
+h2 > a::hover,
+h3 > a::hover,
+h4 > a::hover,
+h5 > a::hover,
+h6 > a::hover,
 .stealth-link::hover {
 	text-decoration: inherit !important;
 	color: inherit !important;
 	cursor: inherit !important;
 }
+
 
 /* transfer from old ui { */
 


### PR DESCRIPTION
Preemptively fixes link style for newly added links inside headings. No task.

This change is required because we used to add `class="stealth-link"` to all headings, but if we're adding it everywhere, we might as well get rid of it and just style the `<a>`s themselves.

Before:
<img width="338" alt="Screen Shot 2020-05-19 at 11 21 52 AM" src="https://user-images.githubusercontent.com/1382374/82352136-2a906500-99c3-11ea-9aa5-b6514982b718.png">
<img width="338" alt="Screen Shot 2020-05-19 at 11 21 49 AM" src="https://user-images.githubusercontent.com/1382374/82352137-2b28fb80-99c3-11ea-86a5-13873e8c7d07.png">

After:
<img width="338" alt="Screen Shot 2020-05-19 at 11 21 32 AM" src="https://user-images.githubusercontent.com/1382374/82352147-2fedaf80-99c3-11ea-8f74-04cbb9fe52e3.png">
