### PR TITLE
Clearfixes for resumes in modals

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2575,6 +2575,19 @@ table.sort-to-match tr {
 	clear: both;
 }
 
+/* Clearfix for resume modals */
+.compare-and-rank-modal > div > div:before {
+	content: "."; 
+	visibility: hidden; 
+	display: block; 
+	height: 0; 
+	clear: both;
+}
+
+.compare-and-rank-modal > div > div.resume-left {
+	clear: both;
+}
+
 .modal {
 	position: fixed;
 	left: 0px;


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1176944199513474

**Test**

Go here in Booster Module 1 and click on buttons to launch resume modals:
<img width="784" alt="Screen Shot 2020-05-21 at 11 00 21 AM" src="https://user-images.githubusercontent.com/62911934/82590315-5857e400-9b52-11ea-9cdd-8274c5a17d63.png">

**Louis's resume**
- Before
<img width="1792" alt="louis-before" src="https://user-images.githubusercontent.com/62911934/82590383-76bddf80-9b52-11ea-8f6d-382768a62d30.png">

- After
<img width="1792" alt="louis-after" src="https://user-images.githubusercontent.com/62911934/82590389-77ef0c80-9b52-11ea-90f1-6a81e3ada713.png">

**Eric's resume**
- Before
<img width="1792" alt="eric-before" src="https://user-images.githubusercontent.com/62911934/82590475-981ecb80-9b52-11ea-86ea-ae777ab77dad.png">

- After: still looks wonky because it needs HTML changes
<img width="1792" alt="eric-after" src="https://user-images.githubusercontent.com/62911934/82590591-d0bea500-9b52-11ea-9b63-2c7cfdd74914.png">

- HTML changes needed to a couple `class` names in Eric's resume:

<img width="1792" alt="eric-html" src="https://user-images.githubusercontent.com/62911934/82590597-d3b99580-9b52-11ea-91f0-d53a2bb7e8ad.png">

**Amanda's resume**

- Before
<img width="1792" alt="amanda-before" src="https://user-images.githubusercontent.com/62911934/82590654-e764fc00-9b52-11ea-8a9d-b9bf8322c090.png">

- After
<img width="1792" alt="amanda-after" src="https://user-images.githubusercontent.com/62911934/82590664-e8962900-9b52-11ea-9816-089857a45340.png">

- HTML changes needed for a bunch of white space, old `<span>` where her name is
<img width="1792" alt="amanda-html" src="https://user-images.githubusercontent.com/62911934/82590697-fcda2600-9b52-11ea-8a02-edc621d1cd06.png">

**Details**

- Clearfixes I destroyed and missed when fixing resume snippets