### PR TITLE
Clean up clearfixes for resumes

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -2049,7 +2049,7 @@ table [type="range"] {
 .bz-magic-field-assignment .timeline li:after,
 .bz-magic-field-submission .timeline li:after {
 	/* clearfix for floats */
-  content: "";
+  	content: "";
 	display: block;
 	height: 0;
 	clear: both;
@@ -2557,37 +2557,24 @@ table.sort-to-match tr {
 
 /* These are clearfix: https://css-tricks.com/all-about-floats/#article-header-id-3 */
 
-/* Clearfix after every inline resume snippet */
-.partial-html-document:after { 
-	content: "."; 
+/* Clearfix after inline resume snippets */
+.partial-html-document:after {
+	content: ""; 
 	visibility: hidden; 
 	display: block; 
 	height: 0; 
 	clear: both;
 }
 
-/* Clearfix before each div in the resume snippet */
-.partial-html-document > div:before {
-	content: "."; 
-	visibility: hidden; 
-	display: block; 
-	height: 0; 
+/* Clearfix resume items not floated to right */
+/* For inline resume snippets */
+.partial-html-document > div:not(.resume-right),
+/* For resume modals */
+.compare-and-rank-modal > div > div:not(.resume-right) {
 	clear: both;
 }
 
-/* Clearfix for resume modals */
-.compare-and-rank-modal > div > div:before {
-	content: "."; 
-	visibility: hidden; 
-	display: block; 
-	height: 0; 
-	clear: both;
-}
-
-.compare-and-rank-modal > div > div.resume-left {
-	clear: both;
-}
-
+/* Resume modals */
 .modal {
 	position: fixed;
 	left: 0px;


### PR DESCRIPTION
**Task**: N/A

**Test**

- Make sure that resumes render the same in Booster Module 1 with these changes
- For inline resume snippets, same test plan as: https://github.com/beyond-z/canvas-lms-js-css/pull/305
- For resume modals, same test plan as: https://github.com/beyond-z/canvas-lms-js-css/pull/311

**Details**

- Rethinking how I did the clearfixes, I think this is cleaner and more readable: 
(1) `clear` all resume content `<div>`s not floated right with `class="resume-right"`,
(2) this means I only have to inject an invisible clearfix element after an inline resume snippet because we need to clear after the last `<div>` of resume content, which could have any number of classes, otherwise, we're covered by (1)
- Also make things more consistent with the other clearfix in the file
