### PR TITLE
Make the question icon CSS target more specific.

### DIFF
--- a/braven_newui.css
+++ b/braven_newui.css
@@ -3406,10 +3406,6 @@ form.bz-app-ritual-opportunity a.bz-app-ritual-calculate-link {
     left: 0;
 }
 
-.question {
-    background-image: url('images/lms-icons-04.png');
-}
-
 blockquote small {
     display: block;
     line-height: 1.25rem;


### PR DESCRIPTION
We already have the following CSS rule in there:
```
.module-block > div.question {
	background-image: url('images/lms-icons-04.png');
}
```
Removing the left over one from before b/c it conflicts with questions in a
FormAssembly form that looks like the following:
```
<div class="wFormContainer">
...
  <fieldset class="fieldset">
  ...
    <div class="question typecheckbox">...</div>
```
### Test Plan:
- Make sure questions in a new module work with this removed. E.g.
  https://portal.bebraven.org/courses/141/pages/lead-authentically?module_item_id=7405
- Make sure questions in an old module use bz_newui.css and not braven_newui.css
  https://portal.bebraven.org/courses/58/pages/live-your-legacy?module_item_id=5374
- Double check that there are no questions on the Braven Resources splash page.
- Make sure the following FormAssembly form doesn't show these icons when you hit "sign and submit"
  https://braven.tfaforms.net/4810809