### PR TITLE
Make the course Home page title match the Portal styling.

### DIFF
--- a/braven_justfont.css
+++ b/braven_justfont.css
@@ -90,9 +90,12 @@ th,
 	text-align: center;
 }
 
-
-
-
+/* Customize the home page */
+/* --------------------------------- */
+#course_home_content .ic-Action-header__Primary h2 {
+    color: #DB2B36;
+    font-size: 2em;
+}
 
 
 /* Customizing the modules list view */


### PR DESCRIPTION
Just making the Highlander course home page title a bit more like the Portal in preparation for demo'ing and sharing it more broadly to other sub-teams
<img src="https://user-images.githubusercontent.com/5596986/94167983-24236580-fe5b-11ea-987a-2f2f0d0179c2.png" width="800">

Note that I also updated the primary red color as described here for accessibility and consistency purposes: https://app.asana.com/0/1174274412967132/1195601639088540

Here is the Portal course Home page for reference:
<img src="https://user-images.githubusercontent.com/5596986/94168320-811f1b80-fe5b-11ea-9810-cac4ba333616.png" width="800">
