### PR TITLE
Style the button where students click to see annotated file feedback.

### DIFF
--- a/braven_theme.js
+++ b/braven_theme.js
@@ -1,0 +1,20 @@
+/* 
+ * This Javascript is uploaded to our Braven Theme on Canvas cloud. E.g.
+ * https://braven.instructure.com/accounts/1/theme_editor
+ */
+
+jQuery(document).ready(function($) {
+
+  // Adds styling to the 'View Feedback' link on an uploaded file submission that has
+  // been annotated by the grader. Allows the student to more easily find it.
+  function styleFileUploadViewAnnotationsLink() {
+    feedback_link = document.querySelector('.file-upload-submission-attachment .modal_preview_link');
+    if (feedback_link) {
+      feedback_link.classList.remove('Button--link');
+      feedback_link.classList.add('Button', 'Button--secondary');
+    }
+  }
+
+  styleFileUploadViewAnnotationsLink();
+  
+});


### PR DESCRIPTION
When a TA annotates a file in an assignment submission, the Fellow
sees the file with this tiny little link that says "View Feedback"
which is hard to find. This just re-style's the link to be a Call To Action
button.

See: https://app.asana.com/0/1174274412967132/1199154572811210

To release this it must be uploaded to the Braven theme on braven.instructure.com

#### Old view:
![image](https://user-images.githubusercontent.com/5596986/98816431-a7dae680-23f6-11eb-8c21-a4f172761499.png)

#### New view:
![image](https://user-images.githubusercontent.com/5596986/98816396-9d205180-23f6-11eb-8d54-e2520fbeddd5.png)
