### PR TITLE
Hide the Previous and Next buttons in Canvas cloud (aka Highlander)

### DIFF
--- a/braven_theme.css
+++ b/braven_theme.css
@@ -1,5 +1,5 @@
-/* braven_justfont.css
- * New Braven Canvas custom CSS, as of Highlander 2020.
+/* braven_theme.css
+ * New Braven Canvas cloud custom CSS, as of Highlander 2020.
  * Add it here: https://braven.instructure.com/accounts/1/theme_editor
  * and be sure to keep the git version https://github.com/beyond-z/canvas-lms-js-css
  * in sync until we find an actual deploy method.
@@ -126,4 +126,11 @@ th,
 }
 .indent_0 {
 	text-transform:uppercase;
+}
+
+/* Hide Previous and Next buttons since we don't use Modules for navigation */
+/* --------------------------------- */
+.module-sequence-footer .module-sequence-footer-button--next, 
+.module-sequence-footer .module-sequence-footer-button--previous {
+  display: none !important;
 }

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -1,7 +1,9 @@
-/* 
- * This Javascript is uploaded to our Braven Theme on Canvas cloud. E.g.
- * https://braven.instructure.com/accounts/1/theme_editor
- */
+/* braven_theme.js
+ * New Braven Canvas cloud custom JS, as of Highlander 2020.
+ * Add it here: https://braven.instructure.com/accounts/1/theme_editor
+ * and be sure to keep the git version https://github.com/beyond-z/canvas-lms-js-css
+ * in sync until we find an actual deploy method.
+ **/
 
 jQuery(document).ready(function($) {
 


### PR DESCRIPTION
Since we're not using Canvas grouping modules to put all the content in a
linear order for the course, the Next/Prev buttons don't make sense.
They navigate between pages using the order on the Homepage or Assignments view.

Task here: https://app.asana.com/0/1174274412967132/1199111886627853

Note: this is "deployed" by uploading it to [the Braven Theme here](https://braven.instructure.com/accounts/1/theme_editor)

#### Test Plan:
- put three assignments in a course
- add them to a Canvas module
- view them as a student and on all three, there should be no Previous or Next button at the bottom.