### PR TITLE
Style out of the box Canvas assignments to look more like Modules/Projects

### DIFF
--- a/braven_theme.css
+++ b/braven_theme.css
@@ -129,11 +129,6 @@ th,
 	font-size: 1.2em;
 }
 
-.assignment .description {
-	font-size: 18px;
-	line-height: 1.25;
-}
-
 .pages.show .show-content {
 	padding: 15px;
 }
@@ -144,6 +139,45 @@ th,
 	background: #DB2B36;
 	padding: 3em;
 	text-align: center;
+}
+
+/* Customize out-of-the-box Assignments (non LTI extensions) */
+/* --------------------------------- */
+.assignment .description {
+    font-size: 1rem;
+    line-height: 1.7;
+    border: 0;
+    max-width: 45rem;
+    padding: 0.75rem;
+    margin: 0.75rem auto;
+}
+
+.assignment .description h2,
+.assignment .description h3,
+.assignment .description h4,
+.assignment .description h5,
+.assignment .description h6 {
+    line-height: 1.7;
+    margin-bottom: 1rem;
+}
+
+.assignment .description p {
+  margin-bottom: 0.75rem;
+}
+
+.assignment .description a {
+  color: #2E6D99; // $bv-blue
+}
+
+.assignment .description ul, 
+.assignment .description ol {
+  padding-left: 1rem;
+  margin-bottom: 1rem;
+}
+
+.assignment .description li {
+    line-height: 1.6;
+    margin-bottom: 0.5rem
 }
 
 /* Customize the home page */


### PR DESCRIPTION
Almost everything is an LTI Extension, but we do have one assignment
"PROJECT: Hustle to Career | Submit Resume and Cover Letter" that is just
an out-of-the-box Canvas assignment. This makes the text content look more
like the rest of our stuff.

Note: braven_theme.css is uploaded to https://braven.instructure.com in order to deploy.

#### BEFORE
![image](https://user-images.githubusercontent.com/5596986/109046014-476c6e00-76a2-11eb-849a-343042d4f86e.png)

#### AFTER
Desktop:
![image](https://user-images.githubusercontent.com/5596986/109046083-5a7f3e00-76a2-11eb-854d-0d976e532146.png)

Mobile (not the app):
<img width="350px" src="https://user-images.githubusercontent.com/5596986/109046136-6b2fb400-76a2-11eb-8eef-b2e5bffa35c0.png">

