### PR TITLE
Customize the page where you launch an LTI assignment into a new window.

### DIFF
--- a/braven_theme.css
+++ b/braven_theme.css
@@ -141,6 +141,19 @@ th,
 	text-align: center;
 }
 
+/* Customize the page to launch the LTI Extension assignments into a new browser window.
+ * This is shown when the "Open in new tab" setting is on for an LTI assignment. */
+/* --------------------------------- */
+.tool_content_wrapper div.load_tab,
+.tool_content_wrapper div.tab_loaded {
+  max-width: 42rem;
+}
+
+.tool_content_wrapper div.load_tab button[type=submit] {
+  margin-top: 1rem;
+}
+
+
 /* Customize out-of-the-box Assignments (non LTI extensions) */
 /* --------------------------------- */
 .assignment .description {

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -18,7 +18,32 @@ jQuery(document).ready(function($) {
   }
 
   styleFileUploadViewAnnotationsLink();
-  
+
+  function customizeLTIAssignmentLaunchPage() {
+    let tabLoaded = document.querySelector('.tool_content_wrapper div.tab_loaded');
+    if (tabLoaded) {
+      tabLoaded.firstChild.textContent = 'This assignment was successfully loaded in a new browser window. Reload the page to access the assignment again.';
+    }
+
+    let loadTab = document.querySelector('.tool_content_wrapper div.load_tab');
+    if (loadTab) {
+      loadTab.firstChild.textContent = 'Click the button below to open this assignment in a new window. You can exit the assignment window at any time and your progress will be automatically saved.';
+
+      let submitButton = loadTab.querySelector('button[type=submit]');
+      if (submitButton) {
+        // Note that after a couple minutes, the text of the button changes to show what's in
+        // this 'data-expired_message' attribute.
+        if (submitButton.dataset.expired_message) {
+          const bravenExpiredMessage = 'The session for this assignment has expired. Please reload the page';
+          submitButton.dataset.expired_message = bravenExpiredMessage;
+        }
+      }
+    }
+
+  }
+
+  customizeLTIAssignmentLaunchPage();
+
 });
 
 ///// Canvas Google Analytics
@@ -102,7 +127,7 @@ function setStorage(key, value, expires) {
 }
 
 async function coursesRequest(courseId) {
-    // 
+    //
     let response = await fetch('/api/v1/users/self/courses?per_page=100');
     let data = await response.text();
     data = data.substr(9);


### PR DESCRIPTION
### Description
We're switching our Modules and Projects to have the "Open in new tab"
setting on. With this on, when you click on a Module or Project
you see a page with a button asking you to click the button to open
the "tool" in a new window. This customizes the language there to not
use "tool" since Fellows know these as assignments. Also, add a little
whitespace to make it look better.

### Test Plan
1. Deploy this into the Braven Theme here: https://braven.instructure.com/accounts/1/brand_configs
1. Configure a Module with the "Load in new Tab" setting
    <img width="250px" src="https://user-images.githubusercontent.com/5596986/112987766-106dfa00-9131-11eb-9242-51d2309ecfda.png">
1. Click on the Module from the assignments page, see the new language
1. Click on the button to launch it, then go back -> see the new language
1. Refresh the page and then leave it open for a few minutes until it expires, see the new language
1. Sanity check that it looks good on tablet and phone sized screens

### Screenshots:
Original load page:
![image](https://user-images.githubusercontent.com/5596986/112987479-c71daa80-9130-11eb-8bce-5506202fe30d.png)

Original "success" page:
![image](https://user-images.githubusercontent.com/5596986/112987511-cd138b80-9130-11eb-8405-8217a1897ef8.png)

Original "expired" page:
![image](https://user-images.githubusercontent.com/5596986/112987543-d56bc680-9130-11eb-884d-a8694f658a9a.png)

New load page:
![image](https://user-images.githubusercontent.com/5596986/112987570-dd2b6b00-9130-11eb-8676-a59f0f5098bb.png)

New "success" page:
![image](https://user-images.githubusercontent.com/5596986/112987588-e3214c00-9130-11eb-91c7-6d183b96365c.png)

New "expired" page:
![image](https://user-images.githubusercontent.com/5596986/112987611-eb798700-9130-11eb-9802-6a8634279921.png)

