### PR TITLE
Hide enrollment controls

### DIFF
--- a/braven_theme.js
+++ b/braven_theme.js
@@ -150,7 +150,7 @@ async function coursesRequest(courseId) {
     //
     let response = await fetch('/api/v1/users/self/courses?per_page=100');
     let data = await response.text();
-    data = data.substr(9);
+    data = data.replace(/^while\(1\);/, '');
     data = JSON.parse(data)
     var stringData = JSON.stringify(data)
     setStorage('ga_enrollments', stringData, null)

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -62,10 +62,7 @@ jQuery(document).ready(function($) {
         'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
       e.parentElement.remove();
     });
-    document.querySelector(
-        'a#addUsers').forEach(e => {
-      e.remove();
-    });
+    document.querySelector('a#addUsers').remove();
 
     // https://braven.instructure.com/courses/{id}/sections/{id}
     document.querySelectorAll(

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -62,6 +62,10 @@ jQuery(document).ready(function($) {
         'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
       e.parentElement.remove();
     });
+    document.querySelector(
+        'a#addUsers').forEach(e => {
+      e.remove();
+    });
 
     // https://braven.instructure.com/courses/{id}/sections/{id}
     document.querySelectorAll(

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -44,6 +44,26 @@ jQuery(document).ready(function($) {
 
   customizeLTIAssignmentLaunchPage();
 
+  // Remove access to user-enrollment controls.
+  // These settings should be edited on Platform instead.
+
+  // https://braven.instructure.com/courses/{id}/users
+  document.querySelectorAll(
+      'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
+    e.parentElement.remove();
+  });
+
+  // https://braven.instructure.com/courses/{id}/sections/{id}
+  document.querySelectorAll(
+      '#current-enrollment-list > ul.user_list > li > span.links').forEach(e => {
+    e.remove();
+  });
+
+  // https://braven.instructure.com/users/{id}
+  document.querySelectorAll(
+      '#courses_list > div.courses > ul.context_list > li > span').forEach(e => {
+    e.remove();
+  });
 });
 
 ///// Canvas Google Analytics

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -46,24 +46,41 @@ jQuery(document).ready(function($) {
 
   // Remove access to user-enrollment controls.
   // These settings should be edited on Platform instead.
+  // Have to use MutationObserver to watch for changes in the DOM, because
+  // half these things are loaded in dynamically via AJAX calls.
+  // See https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver.
+  // Select the node that will be observed for mutations:
+  const targetNode = document.body;
 
-  // https://braven.instructure.com/courses/{id}/users
-  document.querySelectorAll(
-      'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
-    e.parentElement.remove();
-  });
+  // Options for the observer (which mutations to observe).
+  const config = { attributes: false, childList: true, subtree: true };
 
-  // https://braven.instructure.com/courses/{id}/sections/{id}
-  document.querySelectorAll(
-      '#current-enrollment-list > ul.user_list > li > span.links').forEach(e => {
-    e.remove();
-  });
+  // Callback function to execute when mutations are observed.
+  const callback = function(mutationsList, observer) {
+    // https://braven.instructure.com/courses/{id}/users
+    document.querySelectorAll(
+        'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
+      e.parentElement.remove();
+    });
 
-  // https://braven.instructure.com/users/{id}
-  document.querySelectorAll(
-      '#courses_list > div.courses > ul.context_list > li > span').forEach(e => {
-    e.remove();
-  });
+    // https://braven.instructure.com/courses/{id}/sections/{id}
+    document.querySelectorAll(
+        '#current-enrollment-list > ul.user_list > li > span.links').forEach(e => {
+      e.remove();
+    });
+
+    // https://braven.instructure.com/users/{id}
+    document.querySelectorAll(
+        '#courses_list > div.courses > ul.context_list > li > span').forEach(e => {
+      e.remove();
+    });
+  };
+
+  // Create an observer instance linked to the callback function
+  const observer = new MutationObserver(callback);
+
+  // Start observing the target node for configured mutations
+  observer.observe(targetNode, config);
 });
 
 ///// Canvas Google Analytics

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -60,6 +60,7 @@ jQuery(document).ready(function($) {
     // https://braven.instructure.com/courses/{id}/users
     document.querySelectorAll(
         'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
+      console.log('Hiding user enrollment controls');
       e.parentElement.remove();
     });
     document.querySelector('a#addUsers').remove();
@@ -67,12 +68,14 @@ jQuery(document).ready(function($) {
     // https://braven.instructure.com/courses/{id}/sections/{id}
     document.querySelectorAll(
         '#current-enrollment-list > ul.user_list > li > span.links').forEach(e => {
+      console.log('Hiding user enrollment controls');
       e.remove();
     });
 
     // https://braven.instructure.com/users/{id}
     document.querySelectorAll(
         '#courses_list > div.courses > ul.context_list > li > span').forEach(e => {
+      console.log('Hiding user enrollment controls');
       e.remove();
     });
   };


### PR DESCRIPTION
Hides all 4 places where you can modify enrollment on Canvas (that I found):

1. https://braven.instructure.com/courses/42/users dropdown on individual users
2. https://braven.instructure.com/courses/42/users +PEOPLE button
2. https://braven.instructure.com/users/81
3. https://braven.instructure.com/courses/42/sections/200

Task: https://app.asana.com/0/1174274412967132/1200183754300630/f

I had to dig up the MutationObserver stuff from https://github.com/bebraven/platform/pull/646 for this, since most of this stuff is ajax-loaded. That means we're constantly watching all pages on Canvas for all DOM changes now, and I don't know what the performance cost of that might be.

Before Screenshots:

<img width="708" alt="Screen Shot 2021-05-19 at 1 43 23 PM" src="https://user-images.githubusercontent.com/1382374/118867429-b116a580-b8a8-11eb-814b-a2e065a38172.png">
<img width="212" alt="Screen Shot 2021-05-19 at 1 45 01 PM" src="https://user-images.githubusercontent.com/1382374/118867430-b116a580-b8a8-11eb-8141-6ff04b0a6648.png">
<img width="519" alt="Screen Shot 2021-05-19 at 1 46 27 PM" src="https://user-images.githubusercontent.com/1382374/118867436-b1af3c00-b8a8-11eb-96c7-1d7377ebb73f.png">
<img width="1151" alt="Screen Shot 2021-05-19 at 1 55 17 PM" src="https://user-images.githubusercontent.com/1382374/118868763-2fc01280-b8aa-11eb-83ac-cf01ec944698.png">


After Screenshots:

<img width="338" alt="Screen Shot 2021-05-19 at 1 37 18 PM" src="https://user-images.githubusercontent.com/1382374/118866695-e1aa0f80-b8a7-11eb-8fbd-fcee4fda78d9.png">
<img width="836" alt="Screen Shot 2021-05-19 at 1 37 57 PM" src="https://user-images.githubusercontent.com/1382374/118866696-e1aa0f80-b8a7-11eb-8454-6257de5cbdd4.png">
<img width="578" alt="Screen Shot 2021-05-19 at 1 38 35 PM" src="https://user-images.githubusercontent.com/1382374/118866697-e242a600-b8a7-11eb-8a1c-ba2ef51c4be8.png">
<img width="1151" alt="Screen Shot 2021-05-19 at 1 57 21 PM" src="https://user-images.githubusercontent.com/1382374/118868747-2b93f500-b8aa-11eb-8ce1-3dc6595b2885.png">
