### PR TITLE
Set the Help tray links to the standard blue color we use elsewhere.

### DIFF
--- a/braven_theme.css
+++ b/braven_theme.css
@@ -182,7 +182,7 @@ th,
   color: #2E6D99; // $bv-blue
 }
 
-.assignment .description ul, 
+.assignment .description ul,
 .assignment .description ol {
   padding-left: 1rem;
   margin-bottom: 1rem;
@@ -233,7 +233,13 @@ th,
 
 /* Hide Previous and Next buttons since we don't use Modules for navigation */
 /* --------------------------------- */
-.module-sequence-footer .module-sequence-footer-button--next, 
+.module-sequence-footer .module-sequence-footer-button--next,
 .module-sequence-footer .module-sequence-footer-button--previous {
   display: none !important;
+}
+
+/* Customize Help tray */
+/* ---------------------------- */
+#help_tray a {
+  color: #2E6D99; // $bv-blue
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/1174274412967132/1200284637557003

#### Before:
<img width="350px" src="https://user-images.githubusercontent.com/5596986/119846486-2d783c80-bed8-11eb-9bab-42ffbc1c71dc.png">


#### After:
<img width="350px" src="https://user-images.githubusercontent.com/5596986/119846831-76c88c00-bed8-11eb-844b-b5956905933f.png">
