### PR TITLE
Hide more stuff in Canvas to prevent accidents.

### DIFF
--- a/braven_theme.css
+++ b/braven_theme.css
@@ -238,11 +238,17 @@ th,
   display: none !important;
 }
 
-/* Customize global nav menu */
+/* Customize nav */
 /* ---------------------------- */
 
-/* Hide "Commons" */
+/* Hide "Commons" in global nav menu */
 li#context_external_tool_42_menu_item {
+    display: none;
+}
+
+/* Hide "Student View" button. It doesn't work for us with our LTI Extension stuff.
+   Make folks masquerade or create test accounts. */
+a#easy_student_view {
     display: none;
 }
 

--- a/braven_theme.css
+++ b/braven_theme.css
@@ -238,6 +238,15 @@ th,
   display: none !important;
 }
 
+/* Customize global nav menu */
+/* ---------------------------- */
+
+/* Hide "Commons" */
+li#context_external_tool_42_menu_item {
+    display: none;
+}
+
+
 /* Customize Help tray */
 /* ---------------------------- */
 #help_tray a {

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -44,8 +44,10 @@ jQuery(document).ready(function($) {
 
   customizeLTIAssignmentLaunchPage();
 
-  // Remove access to user-enrollment controls.
-  // These settings should be edited on Platform instead.
+  // Remove access to user-enrollment and other controls that should be edited
+  // on Platform instead.
+  // Note that we hide the elements instead of remove them so that if engineers
+  // need to still get in there and use them they can using dev tools.
   // Have to use MutationObserver to watch for changes in the DOM, because
   // half these things are loaded in dynamically via AJAX calls.
   // See https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver.
@@ -61,26 +63,38 @@ jQuery(document).ready(function($) {
     document.querySelectorAll(
         'a[data-event=editSections],a[data-event=editRoles],a[data-event=removeFromCourse]').forEach(e => {
       console.log('Hiding user enrollment controls');
-      e.parentElement.remove();
+      e.parentElement.style.display = "none";
     });
     document.querySelectorAll('a#addUsers').forEach(e => {
       console.log('Hiding add user button');
-      e.remove();
+      e.style.display = "none";
     });
 
     // https://braven.instructure.com/courses/{id}/sections/{id}
     document.querySelectorAll(
         '#current-enrollment-list > ul.user_list > li > span.links').forEach(e => {
       console.log('Hiding user enrollment controls');
-      e.remove();
+      e.style.display = "none";
     });
 
     // https://braven.instructure.com/users/{id}
     document.querySelectorAll(
         '#courses_list > div.courses > ul.context_list > li > span').forEach(e => {
       console.log('Hiding user enrollment controls');
-      e.remove();
+      e.style.display = "none";
     });
+
+    // https://braven.instructure.com/courses/{id}/assignments
+    let assignmentsPageDeleteAssignmentLink = document.querySelector('.assignments ul.al-options a.delete_assignment');
+    if (assignmentsPageDeleteAssignmentLink) {
+      assignmentsPageDeleteAssignmentLink.parentElement.style.display = "none";
+    }
+
+    // https://braven.instructure.com/courses/{id}/assignments/{id}/edit
+    let editPageDeleteAssignmentLink = document.querySelector('.assignment-edit-header a.delete_assignment_link');
+    if (editPageDeleteAssignmentLink) {
+      editPageDeleteAssignmentLink.parentElement.style.display = "none";
+    }
   };
 
   // Create an observer instance linked to the callback function

--- a/braven_theme.js
+++ b/braven_theme.js
@@ -85,10 +85,10 @@ jQuery(document).ready(function($) {
     });
 
     // https://braven.instructure.com/courses/{id}/assignments
-    let assignmentsPageDeleteAssignmentLink = document.querySelector('.assignments ul.al-options a.delete_assignment');
-    if (assignmentsPageDeleteAssignmentLink) {
-      assignmentsPageDeleteAssignmentLink.parentElement.style.display = "none";
-    }
+    document.querySelectorAll('.assignments ul.al-options a.delete_assignment').forEach(e => {
+      console.log('Hiding delete assignment button for ' + e.id);
+      e.parentElement.style.display = "none";
+    });
 
     // https://braven.instructure.com/courses/{id}/assignments/{id}/edit
     let editPageDeleteAssignmentLink = document.querySelector('.assignment-edit-header a.delete_assignment_link');


### PR DESCRIPTION
* [Hide "Delete Assignment" buttons](https://app.asana.com/0/1174274412967132/1199155164193674) from both the assignments list page and the assignment edit page
* [Hide the "Commons" global nav ](https://app.asana.com/0/1174274412967132/1200003854280195)for TAs/staff. Fellows don't see this. We don't want staff to accidentally publish our proprietary stuff
* [Hide the "Student View" button](https://app.asana.com/0/1174274412967132/1200495969693652). This doesn't work with our LTI Extension stuff and it just causes noise.